### PR TITLE
Fixe DateTime conversion for both mono and .Net

### DIFF
--- a/CmisSync.Lib/Cmis/Database.cs
+++ b/CmisSync.Lib/Cmis/Database.cs
@@ -344,7 +344,11 @@ namespace CmisSync.Lib.Cmis
                     object obj = command.ExecuteScalar();
                     // sqlite limitation for DateTime: http://www.sqlite.org/datatype3.html
                     if (null != obj) {
+#if __MonoCS__
                         obj = DateTime.SpecifyKind((DateTime)obj, DateTimeKind.Utc);
+#else
+                        obj = ((DateTime)obj).ToUniversalTime();
+#endif
                     }
                     return (DateTime?)obj;
                 }


### PR DESCRIPTION
Hi Nicolas,

The fixes for the DateTime problem (#200) did not work on DotNet. We wrote some tests and found out, that the ADO connectors from mono (Mono.Data.Sqlite) and DotNet (System.Data.Sqlite) behave both incorrect but each in different way.
Therefore, here is another patch which fixes this.
