### PR TITLE
Check for .NET Framework V4.5 before installing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Extras/log4net-1.2.11/src/log4net.xml
 cmissync-*.zip
 cmissync-*.tar*
 build/cmissync.spec
+/.project

--- a/CmisSync/Windows/CmisSync.wxs
+++ b/CmisSync/Windows/CmisSync.wxs
@@ -1,5 +1,12 @@
 <?xml version='1.0' encoding='windows-1252'?>
-<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'
+	xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
+	
+	<PropertyRef Id="NETFRAMEWORK45"/>
+	
+	<Condition Message="This application requires .NET Framework 4.5. Please install the .NET Framework then run this installer again.">
+    <![CDATA[Installed OR NETFRAMEWORK45]]>
+    </Condition>
 
   <Product Name='CmisSync' Id='bf91eec1-6415-4835-a03b-b76bdf5102ac' UpgradeCode='4c725498-9d2d-43bf-8966-feeace102830'
     Language='1033' Codepage='1252' Version='1.0.2' Manufacturer='CmisSync'>


### PR DESCRIPTION
Not as elegant as installing automatically but until I figure out how bundle/chains work this will do. If you can just compile and put this up somewhere for me to grab I'll test that it actually works.

You'll need to add a reference to WixNetFxExtension.dll, it is located under bin in the Wix install directory.
