### PR TITLE
Fixed XML Comments and Whitespace

### DIFF
--- a/CmisSync.Auth/Password.cs
+++ b/CmisSync.Auth/Password.cs
@@ -5,10 +5,10 @@ using System.Text;
 
 namespace CmisSync.Auth
 {
-    /// <summary>
+/*  /// <summary>
     /// CmisPassword.
     /// </summary>
-    /*public class CmisPassword
+    public class CmisPassword
     {
         private string password = null;
 

--- a/CmisSync.Lib/ChunkedStream.cs
+++ b/CmisSync.Lib/ChunkedStream.cs
@@ -4,11 +4,15 @@ using System.IO;
 
 namespace CmisSync.Lib
 {
+    /// <summary></summary>
     public class ChunkedStream : Stream
     {
         private Stream source;
         private long chunkSize;
 
+        /// <summary></summary>
+        /// <param name="stream"></param>
+        /// <param name="chunk"></param>
         public ChunkedStream(Stream stream, long chunk)
         {
             source = stream;
@@ -20,12 +24,21 @@ namespace CmisSync.Lib
             //}
         }
 
+        /// <summary></summary>
         public override bool CanRead { get { return source.CanRead; } }
+
+        /// <summary></summary>
         public override bool CanWrite { get { return source.CanWrite; } }
+
+        /// <summary></summary>
         public override bool CanSeek { get { return source.CanSeek; } }
+
+        /// <summary></summary>
         public override void Flush() { source.Flush(); }
 
         private long chunkPosition;
+
+        /// <summary></summary>
         public long ChunkPosition
         {
             get
@@ -40,6 +53,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override long Length
         {
             get
@@ -63,6 +77,8 @@ namespace CmisSync.Lib
         }
 
         private long position;
+
+        /// <summary></summary>
         public override long Position
         {
             get
@@ -90,6 +106,11 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        /// <returns></returns>
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (offset < 0)
@@ -110,6 +131,10 @@ namespace CmisSync.Lib
             return count;
         }
 
+        /// <summary></summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
         public override void Write(byte[] buffer, int offset, int count)
         {
             if (offset < 0)
@@ -129,12 +154,18 @@ namespace CmisSync.Lib
             position += count;
         }
 
+        /// <summary></summary>
+        /// <param name="offset"></param>
+        /// <param name="origin"></param>
+        /// <returns></returns>
         public override long Seek(long offset, SeekOrigin origin)
         {
             Debug.Assert(false, "TODO");
             return source.Seek(offset, origin);
         }
 
+        /// <summary></summary>
+        /// <param name="value"></param>
         public override void SetLength(long value)
         {
             Debug.Assert(false, "TODO");

--- a/CmisSync.Lib/Cmis/CmisUtils.cs
+++ b/CmisSync.Lib/Cmis/CmisUtils.cs
@@ -1,4 +1,4 @@
-using DotCMIS;
+﻿using DotCMIS;
 using DotCMIS.Client;
 using DotCMIS.Client.Impl;
 using DotCMIS.Exceptions;
@@ -36,7 +36,6 @@ namespace CmisSync.Lib.Cmis
         }
     }
 
-
     /// <summary>
     /// Useful CMIS methods.
     /// </summary>
@@ -44,9 +43,8 @@ namespace CmisSync.Lib.Cmis
     {
         private static readonly ILog Logger = LogManager.GetLogger(typeof(CmisUtils));
 
-
+        /// <summary></summary>
         public static char CMIS_FILE_SEPARATOR = '/';
-
 
         /// <summary>
         /// Try to find the CMIS server associated to any URL.
@@ -248,14 +246,20 @@ namespace CmisSync.Lib.Cmis
             /// Children.
             /// </summary>
             public List<FolderTree> Children = new List<FolderTree>();
+
             /// <summary>
             /// Folder path.
             /// </summary>
             public string Path;
+
             /// <summary>
             /// Folder name.
             /// </summary>
             public string Name { get; set; }
+
+            /// <summary>
+            /// 
+            /// </summary>
             public bool Finished { get; set; }
 
             /// <summary>

--- a/CmisSync.Lib/Config.cs
+++ b/CmisSync.Lib/Config.cs
@@ -465,6 +465,7 @@ namespace CmisSync.Lib
                 [XmlElement("lastsuccessedsync")]
                 public DateTime LastSuccessedSync { get; set; }
 
+                /// <summary></summary>
                 [XmlElement("syncatstartup")]
                 public bool SyncAtStartup { get; set; }
 
@@ -491,6 +492,8 @@ namespace CmisSync.Lib
                 }
 
                 private int uploadRetries = 2;
+
+                /// <summary></summary>
                 [XmlElement("maxUploadRetries", IsNullable=true)]
                 public int? UploadRetries
                 {
@@ -504,6 +507,8 @@ namespace CmisSync.Lib
                 }
 
                 private int downloadRetries = 2;
+
+                /// <summary></summary>
                 [XmlElement("maxDownloadRetries", IsNullable=true)]
                 public int? DownLoadRetries
                 {
@@ -517,6 +522,8 @@ namespace CmisSync.Lib
                 }
 
                 private int deletionRetries = 2;
+
+                /// <summary></summary>
                 [XmlElement("maxDeletionRetries", IsNullable=true)]
                 public int? DeletionRetries
                 {
@@ -529,6 +536,7 @@ namespace CmisSync.Lib
                     }
                 }
 
+                /// <summary></summary>
                 [XmlElement("features", IsNullable=true)]
                 public Feature SupportedFeatures { get; set;}
 
@@ -539,6 +547,8 @@ namespace CmisSync.Lib
                 public List<IgnoredFolder> IgnoredFolders { get; set; }
 
                 private long chunkSize = DefaultChunkSize;
+
+                /// <summary></summary>
                 [XmlElement("chunkSize"), System.ComponentModel.DefaultValue(DefaultChunkSize)]
                 public long ChunkSize
                 {
@@ -555,7 +565,6 @@ namespace CmisSync.Lib
                         }
                     }
                 }
-
 
                 /// <summary>
                 /// Get all the configured info about a synchronized folder.
@@ -631,24 +640,30 @@ namespace CmisSync.Lib
             public string EMail { get; set; }
         }
 
-
+        /// <summary></summary>
         public class Feature {
+            /// <summary></summary>
             [XmlElement("getFolderTree", IsNullable=true)]
             public bool? GetFolderTreeSupport {get; set;}
+            /// <summary></summary>
             [XmlElement("getDescendants", IsNullable=true)]
             public bool? GetDescendantsSupport {get; set;}
+            /// <summary></summary>
             [XmlElement("getContentChanges", IsNullable=true)]
             public bool? GetContentChangesSupport {get; set;}
+            /// <summary></summary>
             [XmlElement("fileSystemWatcher", IsNullable=true)]
             public bool? FileSystemWatcherSupport {get; set;}
+            /// <summary></summary>
             [XmlElement("maxContentChanges", IsNullable=true)]
             public int? MaxNumberOfContentChanges {get; set;}
+            /// <summary></summary>
             [XmlElement("chunkedSupport", IsNullable=true)]
             public bool? ChunkedSupport {get;set;}
+            /// <summary></summary>
             [XmlElement("chunkedDownloadSupport", IsNullable=true)]
             public bool? ChunkedDownloadSupport {get;set;}
         }
-
 
         /// <summary>
         /// XML URI.

--- a/CmisSync.Lib/Database/Database.cs
+++ b/CmisSync.Lib/Database/Database.cs
@@ -600,17 +600,13 @@ namespace CmisSync.Lib.Database
             parameters.Add("path", item.RemoteRelativePath);
             ExecuteSQLAction(command, parameters);
         }
-            
 
         /// <summary>
         /// Gets the upload retry counter.
         /// </summary>
-        /// <returns>
-        /// The upload retry counter.
-        /// </returns>
-        /// <param name='path'>
-        /// Path of the local file.
-        /// </param>
+        /// <param name="path">Path of the local file.</param>
+        /// <param name="type"></param>
+        /// <returns>The upload retry counter.</returns>
         public long GetOperationRetryCounter(string path, OperationType type)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
@@ -634,16 +630,12 @@ namespace CmisSync.Lib.Database
             { return 0; }
         }
 
-
         /// <summary>
         /// Gets the upload retry counter.
         /// </summary>
-        /// <returns>
-        /// The upload retry counter.
-        /// </returns>
-        /// <param name='path'>
-        /// Path of the local file.
-        /// </param>
+        /// <param name="item">Path of the local file.</param>
+        /// <param name="type"></param>
+        /// <returns>The upload retry counter.</returns>
         public long GetOperationRetryCounter(SyncItem item, OperationType type)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
@@ -667,16 +659,12 @@ namespace CmisSync.Lib.Database
             { return 0; }
         }
 
-
         /// <summary>
         /// Sets the upload retry counter.
         /// </summary>
-        /// <param name='path'>
-        /// Path of the local file.
-        /// </param>
-        /// <param name='counter'>
-        /// Counter.
-        /// </param>
+        /// <param name="item">Path of the local file.</param>
+        /// <param name="counter">Counter.</param>
+        /// <param name="type"></param>
         public void SetOperationRetryCounter(SyncItem item, long counter, OperationType type)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
@@ -724,13 +712,10 @@ namespace CmisSync.Lib.Database
             ExecuteSQLAction(command, parameters);
         }
 
-
         /// <summary>
         /// Deletes the upload retry counter.
         /// </summary>
-        /// <param name='path'>
-        /// Path of the local file.
-        /// </param>
+        /// <param name="item">Path of the local file.</param>
         public void DeleteAllFailedOperations(SyncItem item)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
@@ -738,7 +723,6 @@ namespace CmisSync.Lib.Database
             string command = @"DELETE FROM failedoperations WHERE path=@path";
             ExecuteSQLAction(command, parameters);
         }
-
 
         /// <summary>
         /// Deletes all failed upload counter.
@@ -750,10 +734,10 @@ namespace CmisSync.Lib.Database
             ExecuteSQLAction(command, parameters);
         }
 
-
         /// <summary>
         /// Recalculate the checksum of a file and save it to database.
         /// </summary>
+        /// <param name="syncItem"></param>
         public void RecalculateChecksum(SyncItem syncItem)
         {
             string checksum;
@@ -778,10 +762,11 @@ namespace CmisSync.Lib.Database
             ExecuteSQLAction(command, parameters);
         }
 
-
         /// <summary>
         /// Checks whether the database contains a given item.
         /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
         public bool ContainsFile(SyncItem item)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
@@ -797,18 +782,16 @@ namespace CmisSync.Lib.Database
             }
         }
 
-
-
         /// <summary>
-        /// <returns>path field in files table for <paramref name="id"/></returns>
         /// </summary>
+        /// <param name="id"></param>
+        /// <returns>Path field in files table for <paramref name="id"/></returns>
         public string GetRemoteFilePath(string id)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
             parameters.Add("id", id);
             return Denormalize((string)ExecuteSQLFunction("SELECT path FROM files WHERE id=@id", parameters));
         }
-
 
         /// <summary>
         /// Gets the syncitem from id.
@@ -825,7 +808,6 @@ namespace CmisSync.Lib.Database
             string localPath = (localPathObj is DBNull) ? remotePath : (string)localPathObj;
             return SyncItemFactory.CreateFromPaths(pathPrefix, localPath, remotePathPrefix, remotePath);
         }
-
 
         /// <summary>
         /// Gets the syncitem from local path.
@@ -902,7 +884,6 @@ namespace CmisSync.Lib.Database
 
             return SyncItemFactory.CreateFromPaths(pathPrefix, localPath, remotePathPrefix, normalizedRemotePath);
         }
-            
 
         /// <summary>
         /// Checks whether the database contains a given folder.
@@ -921,7 +902,6 @@ namespace CmisSync.Lib.Database
         /// </summary>
         public bool ContainsFolder(SyncItem item)
         {
-
             Dictionary<string, object> parameters = new Dictionary<string, object>();
             if (item is RemotePathSyncItem)
             {
@@ -935,8 +915,6 @@ namespace CmisSync.Lib.Database
             }
         }
 
-
-
         /// <summary>
         /// <returns>path field in folders table for <paramref name="id"/></returns>
         /// </summary>
@@ -946,7 +924,6 @@ namespace CmisSync.Lib.Database
             parameters.Add("id", id);
             return Denormalize((string)ExecuteSQLFunction("SELECT path FROM folders WHERE id=@id", parameters));
         }
-
 
         /// <summary>
         /// Check whether a file's content has changed locally since it was last synchronized.
@@ -977,7 +954,6 @@ namespace CmisSync.Lib.Database
             return !currentChecksum.Equals(previousChecksum);
         }
 
-
         /// <summary>
         /// Get checksum from database.
         /// Public for debugging purposes only.
@@ -995,7 +971,6 @@ namespace CmisSync.Lib.Database
             return res;
         }
 
-
         /// <summary>
         /// Get the ChangeLog token that was stored at the end of the last successful CmisSync synchronization.
         /// </summary>
@@ -1003,7 +978,6 @@ namespace CmisSync.Lib.Database
         {
             return (string)ExecuteSQLFunction("SELECT value FROM general WHERE key=\"ChangeLogToken\"", null);
         }
-
 
         /// <summary>
         /// Set the stored ChangeLog token.
@@ -1093,7 +1067,6 @@ namespace CmisSync.Lib.Database
             this.remotePathPrefixSize = pathprefix.Length + 1;
         }
 
-
         private object GetGeneralTableValue(string key)
         {
             string command = "SELECT value FROM general WHERE key=@key";
@@ -1103,7 +1076,6 @@ namespace CmisSync.Lib.Database
             return result;
         }
 
-
         private void SetGeneralTableValue(string key, string value)
         {
             string command = "INSERT OR REPLACE INTO general (key, value) VALUES(@key, @value)";
@@ -1112,7 +1084,6 @@ namespace CmisSync.Lib.Database
             parameters.Add("value", value);
             ExecuteSQLAction(command, parameters);
         }
-
 
         /// <summary>
         /// Checks whether the database contains a given folders's id.
@@ -1126,7 +1097,6 @@ namespace CmisSync.Lib.Database
             parameters.Add("@path", path);
             return null != ExecuteSQLFunction("SELECT id FROM folders WHERE path = @path;", parameters);
         }
-
 
         /// <summary>
         /// Helper method to execute an SQL command that does not return anything.
@@ -1149,7 +1119,6 @@ namespace CmisSync.Lib.Database
                 }
             }
         }
-
 
         /// <summary>
         /// Helper method to execute an SQL command that returns something.
@@ -1207,12 +1176,18 @@ namespace CmisSync.Lib.Database
             }
         }
 
-
+        /// <summary></summary>
         public enum OperationType
         {
-            UPLOAD, DOWNLOAD, CHANGE, DELETE
+            /// <summary></summary>
+            UPLOAD,
+            /// <summary></summary>
+            DOWNLOAD,
+            /// <summary></summary>
+            CHANGE,
+            /// <summary></summary>
+            DELETE
         }
-
 
         /// <summary>
         /// Helper method to fill the parameters inside an SQL command.
@@ -1231,7 +1206,6 @@ namespace CmisSync.Lib.Database
                 }
             }
         }
-
 
         private string operationTypeToString(OperationType type)
         {

--- a/CmisSync.Lib/Database/DatabaseMigrationToVersion3.cs
+++ b/CmisSync.Lib/Database/DatabaseMigrationToVersion3.cs
@@ -35,7 +35,7 @@ namespace CmisSync.Lib.Database
         /// <summary>
         /// Migrate from database version 0,2 to version 3.
         /// </summary>
-        /// <param name="filePath">File path.</param>
+        /// <param name="syncFolder">File path.</param>
         /// <param name="connection">Connection.</param>
         /// <param name="currentVersion">Current database schema version.</param>
         public void Migrate(Config.SyncConfig.Folder syncFolder, SQLiteConnection connection, int currentVersion)
@@ -50,12 +50,11 @@ namespace CmisSync.Lib.Database
             SetDatabaseVersion(connection, currentVersion);
         }
 
-
         /// <summary>
         /// Add columns and other database schema manipulation.
         /// </summary>
-        /// <param name="dbFilePath">Db file path.</param>
-        /// <param name="folderName">Folder name.</param>
+        /// <param name="syncFolder">Folder name.</param>
+        /// <param name="connection"></param>
         public static void MigrateSchema(Config.SyncConfig.Folder syncFolder, SQLiteConnection connection)
         {
             // Add columns

--- a/CmisSync.Lib/Events/ConfigChangedEvent.cs
+++ b/CmisSync.Lib/Events/ConfigChangedEvent.cs
@@ -5,21 +5,31 @@ using System.Text;
 
 namespace CmisSync.Lib.Events
 {
+    /// <summary></summary>
     public class ConfigChangedEvent : ISyncEvent
     {
+        /// <summary></summary>
+        /// <returns></returns>
         public override string ToString()
         {
             return "ConfigChangedEvent";
         }
     }
 
+    /// <summary></summary>
     public class RepoConfigChangedEvent : ConfigChangedEvent
     {
+        /// <summary></summary>
         public readonly RepoInfo RepoInfo;
+
+        /// <summary></summary>
+        /// <param name="repoInfo"></param>
         public RepoConfigChangedEvent(RepoInfo repoInfo) {
             RepoInfo = repoInfo;
         }
 
+        /// <summary></summary>
+        /// <returns></returns>
         public override string ToString()
         {
             return String.Format("RepoConfigChangedEvent: {0}", RepoInfo.Name);

--- a/CmisSync.Lib/Events/DebugLoggingHandler.cs
+++ b/CmisSync.Lib/Events/DebugLoggingHandler.cs
@@ -4,17 +4,22 @@ using log4net;
 
 namespace CmisSync.Lib.Events
 {
+    /// <summary></summary>
     public class DebugLoggingHandler : SyncEventHandler
     {
         private static readonly ILog Logger = LogManager.GetLogger(typeof(DebugLoggingHandler));
         private static readonly int DEBUGGINGLOGGERPRIORITY = 10000;
 
+        /// <summary></summary>
+        /// <param name="e"></param>
+        /// <returns></returns>
         public override bool Handle(ISyncEvent e)
         {
             Logger.Debug("Incomming Event: " + e.ToString());
             return false;
         }
 
+        /// <summary></summary>
         public override int Priority
         {
             get {return DEBUGGINGLOGGERPRIORITY;}

--- a/CmisSync.Lib/Events/FSDeletionHandler.cs
+++ b/CmisSync.Lib/Events/FSDeletionHandler.cs
@@ -9,6 +9,7 @@ using CmisSync.Lib.Database;
 
 namespace CmisSync.Lib.Events
 {
+    /// <summary></summary>
     public class FSDeletionHandler : SyncEventHandler
     {
         private Database.Database database;
@@ -19,6 +20,9 @@ namespace CmisSync.Lib.Events
 
         private static readonly int FSDELETIONPRIORITY = 100;
 
+        /// <summary></summary>
+        /// <param name="database"></param>
+        /// <param name="session"></param>
         public FSDeletionHandler(Database.Database database, ISession session)
         {
             if (database == null)
@@ -33,6 +37,9 @@ namespace CmisSync.Lib.Events
             this.session = session;
         }
 
+        /// <summary></summary>
+        /// <param name="e"></param>
+        /// <returns></returns>
         public override bool Handle(ISyncEvent e)
         {
             if(!(e is FSEvent))
@@ -47,6 +54,7 @@ namespace CmisSync.Lib.Events
             return true;
         }
 
+        /// <summary></summary>
         public override int Priority
         {
             get {return FSDELETIONPRIORITY;}

--- a/CmisSync.Lib/Events/FSEvent.cs
+++ b/CmisSync.Lib/Events/FSEvent.cs
@@ -3,6 +3,7 @@ using System.IO;
 
 namespace CmisSync.Lib.Events
 {
+    /// <summary></summary>
     public class FSEvent : ISyncEvent
     {
         /// <summary>
@@ -28,6 +29,8 @@ namespace CmisSync.Lib.Events
             Path = path;
         }
 
+        /// <summary></summary>
+        /// <returns></returns>
         public override string ToString() {
             return string.Format("FSEvent with type \"{0}\" on path \"{1}\"", Type, Path);
         }

--- a/CmisSync.Lib/Events/FileConflictEvent.cs
+++ b/CmisSync.Lib/Events/FileConflictEvent.cs
@@ -7,12 +7,19 @@ namespace CmisSync.Lib.Events
 {
     class FileConflictEvent : ISyncEvent
     {
+        /// <summary></summary>
         public FileConflictType Type { get; private set; }
 
+        /// <summary></summary>
         public string AffectedPath { get; private set; }
 
+        /// <summary></summary>
         public string CreatedConflictPath { get; private set; }
 
+        /// <summary></summary>
+        /// <param name="type"></param>
+        /// <param name="affectedPath"></param>
+        /// <param name="createdConflictPath"></param>
         public FileConflictEvent(FileConflictType type, string affectedPath, string createdConflictPath = null)
         {
             if (affectedPath == null)
@@ -24,6 +31,8 @@ namespace CmisSync.Lib.Events
             CreatedConflictPath = createdConflictPath;
         }
 
+        /// <summary></summary>
+        /// <returns></returns>
         public override string ToString()
         {
             if(CreatedConflictPath == null )
@@ -33,11 +42,17 @@ namespace CmisSync.Lib.Events
         }
     }
 
+    /// <summary></summary>
     public enum FileConflictType {
+        /// <summary></summary>
         DELETED_REMOTE_FILE,
+        /// <summary></summary>
         MOVED_REMOTE_FILE,
+        /// <summary></summary>
         ALREADY_EXISTS_REMOTELY,
+        /// <summary></summary>
         CONTENT_MODIFIED,
+        /// <summary></summary>
         DELETED_REMOTE_PATH
     }
 }

--- a/CmisSync.Lib/Events/FileTransmissionEvent.cs
+++ b/CmisSync.Lib/Events/FileTransmissionEvent.cs
@@ -35,6 +35,9 @@ namespace CmisSync.Lib.Events
         /// </value>
         public string CachePath { get; private set; }
 
+        /// <summary></summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         public delegate void TransmissionEventHandler(object sender, TransmissionProgressEventArgs e);
 
         /// <summary>

--- a/CmisSync.Lib/Events/GenericSyncEventHandler.cs
+++ b/CmisSync.Lib/Events/GenericSyncEventHandler.cs
@@ -5,19 +5,35 @@ using System.Text;
 
 namespace CmisSync.Lib.Events
 {
+    /// <summary></summary>
+    /// <typeparam name="TSyncEventType"></typeparam>
+    /// <param name="e"></param>
+    /// <returns></returns>
     public delegate bool GenericSyncEventDelegate<TSyncEventType>(ISyncEvent e);
+
+    /// <summary></summary>
+    /// <typeparam name="TSyncEventType"></typeparam>
     public class GenericSyncEventHandler<TSyncEventType> : SyncEventHandler
     {
         private int priority;
+        
+        /// <summary></summary>
         public override int Priority { get { return priority; } }
+
         private GenericSyncEventDelegate<TSyncEventType> Handler;
 
+        /// <summary></summary>
+        /// <param name="priority"></param>
+        /// <param name="handler"></param>
         public GenericSyncEventHandler(int priority, GenericSyncEventDelegate<TSyncEventType> handler)
         {
             this.priority = priority;
             Handler = handler;
         }
 
+        /// <summary></summary>
+        /// <param name="e"></param>
+        /// <returns></returns>
         public override bool Handle(ISyncEvent e)
         {
             if (e is TSyncEventType)

--- a/CmisSync.Lib/Events/ISyncEvent.cs
+++ b/CmisSync.Lib/Events/ISyncEvent.cs
@@ -1,7 +1,10 @@
 namespace CmisSync.Lib.Events
 {
+    /// <summary></summary>
     public interface ISyncEvent
     {
+        /// <summary></summary>
+        /// <returns></returns>
         string ToString(); 
     }
 }

--- a/CmisSync.Lib/Events/SyncEventHandler.cs
+++ b/CmisSync.Lib/Events/SyncEventHandler.cs
@@ -4,18 +4,20 @@ using log4net;
 
 namespace CmisSync.Lib.Events
 {
-    ///<summary>
-    ///Base class for all Event-Handlers
-    ///</summary>
+    /// <summary>Base class for all Event-Handlers</summary>
     public abstract class SyncEventHandler : IComparable<SyncEventHandler>, IComparable
     {
+        /// <summary></summary>
+        /// <param name="e"></param>
+        /// <returns></returns>
         public abstract bool Handle(ISyncEvent e);
 
-        ///<summary>
-        ///May not be changed during runtime
-        ///</summary>
+        ///<summary>May not be changed during runtime</summary>
         public abstract int Priority {get;}
 
+        /// <summary></summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
         public int CompareTo(SyncEventHandler other) {
             return Priority.CompareTo(other.Priority);
         }
@@ -30,6 +32,8 @@ namespace CmisSync.Lib.Events
             return this.CompareTo(other);
         }
 
+        /// <summary></summary>
+        /// <returns></returns>
         public override string ToString() {
             return this.GetType() + " with Priority " + Priority.ToString();
         }

--- a/CmisSync.Lib/Events/SyncEventManager.cs
+++ b/CmisSync.Lib/Events/SyncEventManager.cs
@@ -5,16 +5,20 @@ using System.Collections.Generic;
 
 namespace CmisSync.Lib.Events
 {
+    /// <summary></summary>
     public class SyncEventManager
     {
         private static readonly ILog logger = LogManager.GetLogger(typeof(SyncEventManager));
 
         private List<SyncEventHandler> handler = new List<SyncEventHandler>();
         
+        /// <summary></summary>
         public SyncEventManager()
         {
         }
 
+        /// <summary></summary>
+        /// <param name="h"></param>
         public void AddEventHandler(SyncEventHandler h)
         {
             //The zero-based index of item in the sorted List<T>, 
@@ -28,6 +32,8 @@ namespace CmisSync.Lib.Events
             handler.Insert(pos, h);
         }
 
+        /// <summary></summary>
+        /// <param name="e"></param>
         public virtual void Handle(ISyncEvent e) {
             for(int i = handler.Count-1; i >= 0; i--)
             {
@@ -39,6 +45,8 @@ namespace CmisSync.Lib.Events
             }
         }
 
+        /// <summary></summary>
+        /// <param name="h"></param>
         public void RemoveEventHandler(SyncEventHandler h)
         {
             handler.Remove(h);

--- a/CmisSync.Lib/Events/SyncEventQueue.cs
+++ b/CmisSync.Lib/Events/SyncEventQueue.cs
@@ -6,6 +6,7 @@ using log4net;
 
 namespace CmisSync.Lib.Events
 {
+    /// <summary></summary>
     public class SyncEventQueue : IDisposable {
         private static readonly ILog Logger = LogManager.GetLogger(typeof(SyncEventQueue));
 
@@ -17,9 +18,7 @@ namespace CmisSync.Lib.Events
 
         private bool alreadyDisposed = false;
 
-        /// <summary>
-        /// Constructor.
-        /// </summary>
+        /// <summary>Constructor.</summary>
         public SyncEventQueue(SyncEventManager manager)
         {
             if (manager == null)
@@ -64,7 +63,9 @@ namespace CmisSync.Lib.Events
             Logger.Debug("Stopping to listen on SyncEventQueue");
         }
 
-        /// <exception cref="InvalidOperationException">When Listener is already stopped</exception>
+        /// <summary></summary>
+        /// <param name="newEvent"></param>
+        /// <exception cref="InvalidOperationException"></exception>
         public void AddEvent(ISyncEvent newEvent) {
             if(alreadyDisposed) {
                 throw new ObjectDisposedException("SyncEventQueue", "Called AddEvent on Disposed object");
@@ -72,6 +73,7 @@ namespace CmisSync.Lib.Events
             this.queue.Add(newEvent);
         } 
 
+        /// <summary></summary>
         public void StopListener() {
             if(alreadyDisposed) {
                 return;
@@ -79,17 +81,21 @@ namespace CmisSync.Lib.Events
             this.queue.CompleteAdding();
         }            
         
+        /// <summary></summary>
         public bool IsStopped {
             get { 
                 return this.consumer.IsCompleted; 
             }
         }
 
+        /// <summary></summary>
         public void Dispose() {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary></summary>
+        /// <param name="isDisposing"></param>
         protected virtual void Dispose(bool isDisposing) {
             if(alreadyDisposed) {
                 return;

--- a/CmisSync.Lib/RepoInfo.cs
+++ b/CmisSync.Lib/RepoInfo.cs
@@ -119,10 +119,11 @@ namespace CmisSync.Lib
         /// </value>
         public long MaxUploadRetries { get; set; }
 
+        /// <summary></summary>
         public long MaxDownloadRetries { get; set; }
 
+        /// <summary></summary>
         public long MaxDeletionRetries { get; set; }
-
 
         /// <summary>
         /// Simple constructor.
@@ -134,7 +135,6 @@ namespace CmisSync.Lib
             name = name.Replace("/", "_");
             CmisDatabase = Path.Combine(cmisDatabaseFolder, name + ".cmissync");
         }
-
 
         /// <summary>
         /// Full constructor.

--- a/CmisSync.Lib/Sync/CmisRepo.cs
+++ b/CmisSync.Lib/Sync/CmisRepo.cs
@@ -21,7 +21,7 @@ using CmisSync.Lib.Events;
 
 namespace CmisSync.Lib.Sync
 {
-
+    /// <summary></summary>
     public partial class CmisRepo : RepoBase
     {
         /// <summary>
@@ -29,12 +29,10 @@ namespace CmisSync.Lib.Sync
         /// </summary>
         private SynchronizedFolder synchronizedFolder;
 
-
         /// <summary>
         /// Track whether <c>Dispose</c> has been called.
         /// </summary>
         private bool disposed = false;
-
 
         /// <summary>
         /// Constructor.
@@ -48,7 +46,7 @@ namespace CmisSync.Lib.Sync
             Logger.Info(synchronizedFolder);
         }
 
-
+        /// <summary></summary>
         public override void Resume()
         {
             if(this.synchronizedFolder != null)
@@ -61,13 +59,14 @@ namespace CmisSync.Lib.Sync
         }
 
         /// <summary>
-        /// Some file activity has been detected, add to queue
+        /// Some file activity has been detected, add to queue.
         /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
         public void OnFileActivity(object sender, FileSystemEventArgs args)
         {
             synchronizedFolder.Queue.AddEvent(new FSEvent(args.ChangeType, args.FullPath));
         }
-
 
         /// <summary>
         /// Dispose pattern implementation.
@@ -85,7 +84,6 @@ namespace CmisSync.Lib.Sync
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Whether this folder's synchronization is running right now.
         /// </summary>
@@ -94,7 +92,6 @@ namespace CmisSync.Lib.Sync
             return this.synchronizedFolder.isSyncing();
         }
 
-
         /// <summary>
         /// Whether this folder's synchronization is suspended right now.
         /// </summary>
@@ -102,7 +99,6 @@ namespace CmisSync.Lib.Sync
         {
             return this.synchronizedFolder.isSuspended();
         }
-
 
         /// <summary>
         /// Synchronize.
@@ -123,7 +119,6 @@ namespace CmisSync.Lib.Sync
             }
         }
 
-
         /// <summary>
         /// Synchronize.
         /// The synchronization is performed in the background, so that the UI stays usable.
@@ -132,7 +127,6 @@ namespace CmisSync.Lib.Sync
         {
             SyncInBackground(true);
         }
-
 
         /// <summary>
         /// Synchonize.
@@ -153,7 +147,6 @@ namespace CmisSync.Lib.Sync
                 }
             }
         }
-
 
         /// <summary>
         /// The synchronization is performed in synchronous.

--- a/CmisSync.Lib/Sync/SynchronizedFolder.cs
+++ b/CmisSync.Lib/Sync/SynchronizedFolder.cs
@@ -24,7 +24,6 @@ namespace CmisSync.Lib.Sync
         // Log.
         private static readonly ILog Logger = LogManager.GetLogger(typeof(CmisRepo));
 
-
         /// <summary>
         /// Synchronization with a particular CMIS folder.
         /// </summary>
@@ -35,25 +34,21 @@ namespace CmisSync.Lib.Sync
             /// </summary>
             private static readonly ILog Logger = LogManager.GetLogger(typeof(SynchronizedFolder));
 
-
             /// <summary>
             /// Interval for which sync will wait while paused before retrying sync.
             /// </summary>
             private static readonly int SYNC_SUSPEND_SLEEP_INTERVAL = 1 * 1000; //five seconds
-
 
             /// <summary>
             /// An object for locking the sync method (one thread at a time can run sync).
             /// </summary>
             private Object syncLock = new Object();
 
-
             /// <summary>
             /// Whether sync is bidirectional or only from server to client.
             /// TODO make it a CMIS folder - specific setting
             /// </summary>
             private bool BIDIRECTIONAL = true;
-
 
             /// <summary>
             /// At which degree the repository supports Change Logs.
@@ -80,19 +75,16 @@ namespace CmisSync.Lib.Sync
             /// </summary>
             private bool IsPropertyChangesSupported = false;
 
-
             /// <summary>
             /// Session to the CMIS repository.
             /// </summary>
             private ISession session;
-
 
             /// <summary>
             /// Path of the root in the remote repository.
             /// Example: "/User Homes/nicolas.raoul/demos"
             /// </summary>
             private string remoteFolderPath;
-
 
             /// <summary>
             /// Syncing lock.
@@ -101,79 +93,66 @@ namespace CmisSync.Lib.Sync
             /// </summary>
             private bool syncing;
 
-
             /// <summary>
             /// Whether sync is actually being in pause right now.
             /// This is different from CmisRepo.Status, which means "paused, or will be paused as soon as possible"
             /// </summary>
             private bool suspended = false;
 
-
             /// <summary>
             /// Listener we inform about activity (used by spinner).
             /// </summary>
             private IActivityListener activityListener;
-
 
             /// <summary>
             /// Parameters to use for all CMIS requests.
             /// </summary>
             private Dictionary<string, string> cmisParameters;
 
-
             /// <summary>
             /// Track whether <c>Dispose</c> has been called.
             /// </summary>
             private bool disposed = false;
-
 
             /// <summary>
             /// Track whether <c>Dispose</c> has been called.
             /// </summary>
             private Object disposeLock = new Object();
 
-
             /// <summary>
             /// Database to cache remote information from the CMIS server.
             /// </summary>
             private Database.Database database;
-
 
             /// <summary>
             /// Configuration of the CmisSync synchronized folder, as defined in the XML configuration file.
             /// </summary>
             private RepoInfo repoinfo;
 
-
             /// <summary>
             /// Link to parent object.
             /// </summary>
             private RepoBase repo;
 
-            
             /// <summary>
             /// EventQueue
             /// </summary>
             public SyncEventQueue Queue {get; private set;}
-            
 
             /// <summary>
             /// Set for first sync.
             /// </summary>
             private bool firstSync = false;
 
-
             /// <summary>
             /// Background worker for sync.
             /// </summary>
             private BackgroundWorker syncWorker;
 
-
             /// <summary>
             /// Event to notify that the sync has completed.
             /// </summary>
             private AutoResetEvent autoResetEvent = new AutoResetEvent(true);
-
 
             /// <summary>
             ///  Constructor for Repo (at every launch of CmisSync)
@@ -241,7 +220,6 @@ namespace CmisSync.Lib.Sync
                 );
             }
 
-
             /// <summary>
             /// This method is called, every time the config changes
             /// </summary>
@@ -272,7 +250,6 @@ namespace CmisSync.Lib.Sync
                 cmisParameters[SessionParameter.ReadTimeout] = "60000"; // One Minute
             }
 
-
             /// <summary>
             ///  Update Settings.
             /// </summary>
@@ -296,7 +273,6 @@ namespace CmisSync.Lib.Sync
                 Dispose(false);
             }
 
-
             /// <summary>
             /// Implement IDisposable interface. 
             /// </summary>
@@ -305,7 +281,6 @@ namespace CmisSync.Lib.Sync
                 Dispose(true);
                 GC.SuppressFinalize(this);
             }
-
 
             /// <summary>
             /// Dispose pattern implementation.
@@ -325,7 +300,6 @@ namespace CmisSync.Lib.Sync
                 }
             }
 
-
             /// <summary>
             /// Resets all the failed upload to zero.
             /// </summary>
@@ -333,7 +307,6 @@ namespace CmisSync.Lib.Sync
             {
                 database.DeleteAllFailedOperations();
             }
-
 
             /// <summary>
             /// Connect to the CMIS repository.
@@ -385,7 +358,6 @@ namespace CmisSync.Lib.Sync
                     session.DefaultContext = session.CreateOperationContext(filters, false, true, false, IncludeRelationshipsFlag.None, null, true, null, true, 100);
             }
 
-
             /// <summary>
             /// Whether this folder's synchronization is running right now.
             /// </summary>
@@ -393,7 +365,6 @@ namespace CmisSync.Lib.Sync
             {
                 return this.syncing;
             }
-
 
             /// <summary>
             /// Synchronize between CMIS folder and local folder.
@@ -403,7 +374,6 @@ namespace CmisSync.Lib.Sync
                 return syncWorker.IsBusy;
             }
 
-
             /// <summary>
             /// Whether this folder's synchronization is suspended right now.
             /// </summary>
@@ -411,7 +381,6 @@ namespace CmisSync.Lib.Sync
             {
                 return this.suspended;
             }
-
 
             /// <summary>
             /// Synchronize between CMIS folder and local folder.
@@ -421,12 +390,10 @@ namespace CmisSync.Lib.Sync
                 Sync(true);
             }
 
-            
             /// <summary>
             /// Track whether a full sync is done
             /// </summary>
             private bool syncFull = false;
-
 
             /// <summary>
             /// Forces the full sync independent of FS events or Remote events.
@@ -1603,10 +1570,10 @@ namespace CmisSync.Lib.Sync
                 return metadata;
             }
 
-            /// <summary>
+/*          /// <summary>
             /// Rename a file remotely.
             /// </summary>
-/*            private bool RenameFile(string directory, string newFilename, IDocument remoteFile)
+            private bool RenameFile(string directory, string newFilename, IDocument remoteFile)
             {
                 SleepWhileSuspended();
 

--- a/CmisSync.Lib/SyncItem.cs
+++ b/CmisSync.Lib/SyncItem.cs
@@ -5,104 +5,149 @@ using CmisSync.Lib.Cmis;
 
 namespace CmisSync.Lib
 {
+    /// <summary></summary>
     abstract public class SyncItem
     {
-        // local Repository root folder
+        /// <summary>local Repository root folder</summary>
         protected string localRoot;
 
-        // remote Repository root folder
+        /// <summary>remote Repository root folder</summary>
         protected string remoteRoot;
 
-        // local relative path
+        /// <summary>local relative path</summary>
         protected string localPath;
 
-        // remote relative path
+        /// <summary>remote relative path</summary>
         protected string remotePath;
 
-
+        /// <summary></summary>
         protected SyncItem()
         {
         }
 
+        /// <summary></summary>
         abstract public string LocalRelativePath
         {
             get;
         }
 
+        /// <summary></summary>
         abstract public string RemoteRelativePath
         {
             get;
         }
 
+        /// <summary></summary>
         abstract public string LocalPath
         {
             get;
         }
-       
+
+        /// <summary></summary>
         abstract public string RemotePath
         {
             get;
         }
 
+        /// <summary></summary>
         abstract public string LocalFileName
         {
             get;
         }
 
+        /// <summary></summary>
         abstract public string RemoteFileName
         {
             get;
         }
 
+        /// <summary></summary>
+        /// <returns></returns>
         virtual public bool ExistsLocal()
         {
             return File.Exists(LocalPath);
         }
     }
 
-
+    /// <summary></summary>
     public static class SyncItemFactory
     {
-
+        /// <summary></summary>
+        /// <param name="path"></param>
+        /// <param name="repoInfo"></param>
+        /// <returns></returns>
         public static SyncItem CreateFromLocalPath(string path, RepoInfo repoInfo)
         {
             return new LocalPathSyncItem(path, repoInfo);
         }
 
+        /// <summary></summary>
+        /// <param name="folder"></param>
+        /// <param name="fileName"></param>
+        /// <param name="repoInfo"></param>
+        /// <returns></returns>
         public static SyncItem CreateFromLocalPath(string folder, string fileName, RepoInfo repoInfo)
         {
             return new LocalPathSyncItem(Path.Combine(folder, fileName), repoInfo);
         }
 
+        /// <summary></summary>
+        /// <param name="path"></param>
+        /// <param name="repoInfo"></param>
+        /// <returns></returns>
         public static SyncItem CreateFromRemotePath(string path, RepoInfo repoInfo)
         {
             return new RemotePathSyncItem(path, repoInfo);
         }
-            
+
+        /// <summary></summary>
+        /// <param name="folder"></param>
+        /// <param name="fileName"></param>
+        /// <param name="repoInfo"></param>
+        /// <returns></returns>
         public static SyncItem CreateFromRemotePath(string folder, string fileName, RepoInfo repoInfo)
         {
             return new RemotePathSyncItem(Path.Combine(folder, fileName), repoInfo);
         }
 
+        /// <summary></summary>
+        /// <param name="localFolder"></param>
+        /// <param name="remoteFileName"></param>
+        /// <param name="repoInfo"></param>
+        /// <returns></returns>
         public static SyncItem CreateFromLocalFolderAndRemoteName(string localFolder, string remoteFileName, RepoInfo repoInfo)
         {
             return new LocalPathSyncItem(localFolder, remoteFileName, repoInfo);
         }
 
+        /// <summary></summary>
+        /// <param name="remoteFolder"></param>
+        /// <param name="LocalFileName"></param>
+        /// <param name="repoInfo"></param>
+        /// <returns></returns>
         public static SyncItem CreateFromRemoteFolderAndLocalName(string remoteFolder, string LocalFileName, RepoInfo repoInfo)
         {
             return new RemotePathSyncItem(remoteFolder, LocalFileName, repoInfo);
         }
 
+        /// <summary></summary>
+        /// <param name="localPathPrefix"></param>
+        /// <param name="localPath"></param>
+        /// <param name="remotePathPrefix"></param>
+        /// <param name="remotePath"></param>
+        /// <returns></returns>
         public static SyncItem CreateFromPaths(string localPathPrefix, string localPath, string remotePathPrefix, string remotePath)
         {
             return new LocalPathSyncItem(localPathPrefix, localPath, remotePathPrefix, remotePath);
         }
     }
                
-
+    /// <summary></summary>
     public class LocalPathSyncItem : SyncItem
     {
+        /// <summary></summary>
+        /// <param name="localPath"></param>
+        /// <param name="repoInfo"></param>
         public LocalPathSyncItem(string localPath, RepoInfo repoInfo)
         {
             this.localRoot = repoInfo.TargetDirectory;
@@ -116,6 +161,10 @@ namespace CmisSync.Lib
             this.remotePath = PathRepresentationConverter.LocalToRemote(this.localPath);
         }
 
+        /// <summary></summary>
+        /// <param name="localFolder"></param>
+        /// <param name="remoteRelativePath"></param>
+        /// <param name="repoInfo"></param>
         public LocalPathSyncItem(string localFolder, string remoteRelativePath, RepoInfo repoInfo)
         {
             this.localRoot = repoInfo.TargetDirectory;
@@ -134,6 +183,11 @@ namespace CmisSync.Lib
             this.remotePath = CmisUtils.PathCombine(PathRepresentationConverter.LocalToRemote(localRootRelative), remoteRelativePath);
         }
 
+        /// <summary></summary>
+        /// <param name="localPrefix"></param>
+        /// <param name="localPath"></param>
+        /// <param name="remotePrefix"></param>
+        /// <param name="remotePath"></param>
         public LocalPathSyncItem(string localPrefix, string localPath, string remotePrefix, string remotePath)
         {
             this.localRoot = localPrefix;
@@ -142,7 +196,7 @@ namespace CmisSync.Lib
             this.remotePath = remotePath;
         }
             
-
+        /// <summary></summary>
         public override string LocalRelativePath
         {
             get
@@ -151,6 +205,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override string RemoteRelativePath
         {
             get
@@ -159,6 +214,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override string LocalPath
         {
             get
@@ -167,6 +223,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override string RemotePath
         {
             get
@@ -175,6 +232,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override string LocalFileName
         {
             get
@@ -183,6 +241,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override string RemoteFileName
         {
             get
@@ -192,9 +251,12 @@ namespace CmisSync.Lib
         }
     }
 
-
+    /// <summary></summary>
     public class RemotePathSyncItem : SyncItem
     {
+        /// <summary></summary>
+        /// <param name="remotePath"></param>
+        /// <param name="repoInfo"></param>
         public RemotePathSyncItem(string remotePath, RepoInfo repoInfo)
         {
             this.localRoot = PathRepresentationConverter.RemoteToLocal(repoInfo.TargetDirectory);
@@ -208,6 +270,10 @@ namespace CmisSync.Lib
             this.localPath = PathRepresentationConverter.RemoteToLocal(this.remotePath);
         }
 
+        /// <summary></summary>
+        /// <param name="remoteFolder"></param>
+        /// <param name="localRelativePath"></param>
+        /// <param name="repoInfo"></param>
         public RemotePathSyncItem(string remoteFolder, string localRelativePath, RepoInfo repoInfo)
         {
             this.localRoot = repoInfo.TargetDirectory;
@@ -226,6 +292,7 @@ namespace CmisSync.Lib
             this.localPath = Path.Combine(PathRepresentationConverter.RemoteToLocal(remoteRootRelative), localRelativePath);
         }
 
+        /// <summary></summary>
         public override string LocalRelativePath
         {
             get
@@ -234,6 +301,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override string RemoteRelativePath
         {
             get
@@ -241,7 +309,8 @@ namespace CmisSync.Lib
                 return remotePath;
             }
         }
-            
+        
+        /// <summary></summary>
         public override string LocalPath
         {
             get
@@ -250,6 +319,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override string RemotePath
         {
             get
@@ -258,6 +328,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override string LocalFileName
         {
             get
@@ -266,6 +337,7 @@ namespace CmisSync.Lib
             }
         }
 
+        /// <summary></summary>
         public override string RemoteFileName
         {
             get
@@ -275,47 +347,63 @@ namespace CmisSync.Lib
         }
     }
 
-
-    /// <summary>
-    /// Path representation converter.
-    /// </summary>
+    /// <summary>Path representation converter.</summary>
     public interface IPathRepresentationConverter
     {
+        /// <summary></summary>
+        /// <param name="localPath"></param>
+        /// <returns></returns>
         string LocalToRemote(string localPath);
 
+        /// <summary></summary>
+        /// <param name="remotePath"></param>
+        /// <returns></returns>
         string RemoteToLocal(string remotePath);
     }
 
-
+    /// <summary></summary>
     public class DefaultPathRepresentationConverter : IPathRepresentationConverter
     {
+        /// <summary></summary>
+        /// <param name="localPath"></param>
+        /// <returns></returns>
         public string LocalToRemote(string localPath)
         {
             return localPath;
         }
+
+        /// <summary></summary>
+        /// <param name="remotePath"></param>
+        /// <returns></returns>
         public string RemoteToLocal(string remotePath)
         {
             return remotePath;
         }
     }
 
-    /// <summary>
-    /// Path representation converter.
-    /// </summary>
+    /// <summary>Path representation converter.</summary>
     public static class PathRepresentationConverter
     {
         private static IPathRepresentationConverter PathConverter = new DefaultPathRepresentationConverter();
 
+        /// <summary></summary>
+        /// <param name="converter"></param>
         static public void SetConverter(IPathRepresentationConverter converter)
         {
             PathConverter = converter;
         }
 
+        /// <summary></summary>
+        /// <param name="localPath"></param>
+        /// <returns></returns>
         static public string LocalToRemote(string localPath)
         {
             return PathConverter.LocalToRemote(localPath);
         }
 
+        /// <summary></summary>
+        /// <param name="remotePath"></param>
+        /// <returns></returns>
         static public string RemoteToLocal(string remotePath)
         {
             return PathConverter.RemoteToLocal(remotePath);

--- a/CmisSync.Lib/Utils.cs
+++ b/CmisSync.Lib/Utils.cs
@@ -114,11 +114,7 @@ namespace CmisSync.Lib
             return writeAllow && !writeDeny;
         }
 
-
-        /// <summary>
         /// Names of files that must be excluded from synchronization.
-
-        /// </summary>
         private static HashSet<String> ignoredFilenames = new HashSet<String>{
             "~", // gedit and emacs
             "thumbs.db", "desktop.ini", // Windows
@@ -256,9 +252,9 @@ namespace CmisSync.Lib
             return true;
         }
 
+        /// <summary>
         /// Check whether the file is worth syncing or not.
         /// This optionally excludes blank files or files too large.
-
         /// </summary>
         public static bool IsFileWorthSyncing(string filepath, RepoInfo repoInfo)
         {
@@ -267,7 +263,6 @@ namespace CmisSync.Lib
                 bool allowBlankFiles = true; //TODO: add a preference repoInfo.allowBlankFiles
                 bool limitFilesize = false; //TODO: add preference for filesize limiting
                 long filesizeLimit = 256 * 1024 * 1024; //TODO: add a preference for filesize limit
-
 
                 FileInfo fileInfo = new FileInfo(filepath);
 
@@ -315,21 +310,17 @@ namespace CmisSync.Lib
                 IsFileWorthSyncing(Path.Combine(localDirectory, filename), repoInfo);
         }
 
+        /// <summary>
         /// Determines whether this instance is valid ISO-8859-1 specified input.
         /// </summary>
-        /// <returns>
-        /// <c>true</c> if this instance is valid ISO-8859-1 specified input; otherwise, <c>false</c>.
-        /// </returns>
-        /// <param name='input'>
-        /// If set to <c>true</c> input.
-        /// </param>
+        /// <param name="input">If set to <c>true</c> input.</param>
+        /// <returns><c>true</c> if this instance is valid ISO-8859-1 specified input; otherwise, <c>false</c>.</returns>
         public static bool IsValidISO88591(string input)
         {
             byte[] bytes = Encoding.GetEncoding(28591).GetBytes(input);
             String result = Encoding.GetEncoding(28591).GetString(bytes);
             return String.Equals(input, result);
         }
-
 
         /// <summary>
         /// Check whether the file is worth syncing or not.
@@ -379,13 +370,11 @@ namespace CmisSync.Lib
             return ret;
         }
 
-
         /// <summary>
         /// Regular expression to check whether a file name is valid or not.
         /// </summary>
         private static Regex invalidFileNameRegex = new Regex(
             "[" + Regex.Escape(new string(Path.GetInvalidFileNameChars())+"\"?:/\\|<>*") + "]");
-
 
         /// <summary>
         /// Check whether a folder name is valid or not.
@@ -402,13 +391,11 @@ namespace CmisSync.Lib
             return ret;
         }
 
-
         /// <summary>
         /// Regular expression to check whether a filename is valid or not.
         /// </summary>
         private static Regex invalidFolderNameRegex = new Regex(
             "[" + Regex.Escape(new string(Path.GetInvalidPathChars())+"\"?:/\\|<>*") + "]");
-
 
         /// <summary>
         /// Find an available conflict free filename for this file.
@@ -447,8 +434,7 @@ namespace CmisSync.Lib
                 while (true);
             }
         }
-        
-        
+
         /// <summary>
         /// Format a file size nicely.
         /// Example: 1048576 becomes "1 MB"
@@ -513,7 +499,6 @@ namespace CmisSync.Lib
             return FormatBandwidth((double) bitsPerSecond);
         }
 
-        
         /// <summary>
         /// Whether a file or directory is a symbolic link.
         /// </summary>

--- a/CmisSync.Lib/Watcher.cs
+++ b/CmisSync.Lib/Watcher.cs
@@ -142,11 +142,12 @@ namespace CmisSync.Lib
             }
         }
 
-
         /// <summary>
-        /// insert <param name="name">the file/folder</param> for <param name="change"/> in changes
-        /// It should do nothing if <param name="name">the file/folder</param> exists in changes
+        /// Insert the file/folder for change parameter.
+        /// It should do nothing if the file/folder exists in changes.
         /// </summary>
+        /// <param name="name">the file/folder</param>
+        /// <param name="change"></param>
         public void InsertChange(string name, ChangeTypes change)
         {
             if (ChangeTypes.None == change)

--- a/CmisSync/ControllerBase.cs
+++ b/CmisSync/ControllerBase.cs
@@ -44,41 +44,36 @@ namespace CmisSync
         /// </summary>
         protected static readonly ILog Logger = LogManager.GetLogger(typeof(ControllerBase));
 
-
         /// <summary>
         /// Whether it is the first time that CmisSync is being run.
         /// </summary>
         private bool firstRun;
-
 
         /// <summary>
         /// All the info about the CmisSync synchronized folder being created.
         /// </summary>
         private RepoInfo repoInfo;
 
-
         /// <summary>
         /// Whether the repositories have finished loading.
         /// </summary>
         public bool RepositoriesLoaded { get; private set; }
-
 
         /// <summary>
         /// List of the CmisSync synchronized folders.
         /// </summary>
         private List<RepoBase> repositories = new List<RepoBase>();
 
-
         /// <summary>
         /// Path where the CmisSync synchronized folders are by default.
         /// </summary>
         public string FoldersPath { get; private set; }
 
-
         /// <summary>
         /// Show setup window event.
         /// </summary>
         public event ShowSetupWindowEventHandler ShowSetupWindowEvent = delegate { };
+
         /// <summary>
         /// Show setup window event.
         /// </summary>
@@ -94,20 +89,26 @@ namespace CmisSync
         /// </summary>
         public event Action FolderListChanged = delegate { };
 
+        /// <summary>
+        /// 
+        /// </summary>
         public event Action OnTransmissionListChanged = delegate { };
 
         /// <summary>
         /// Called with status changes to idle.
         /// </summary>
         public event Action OnIdle = delegate { };
+
         /// <summary>
         /// Called with status changes to syncing.
         /// </summary>
         public event Action OnSyncing = delegate { };
+
         /// <summary>
         /// Called with status changes to error.
         /// </summary>
         public event Action<Tuple<string, Exception>> OnError = delegate { };
+
         /// <summary>
         /// Called with status changes to error resolved.
         /// </summary>
@@ -117,11 +118,11 @@ namespace CmisSync
         /// Alert notification.
         /// </summary>
         public event AlertNotificationRaisedEventHandler AlertNotificationRaised = delegate { };
+
         /// <summary>
         /// Alert notification.
         /// </summary>
         public delegate void AlertNotificationRaisedEventHandler(string title, string message);
-
 
         /// <summary>
         /// Get the repositories configured in CmisSync.
@@ -135,7 +136,6 @@ namespace CmisSync
             }
         }
 
-
         /// <summary>
         /// Whether it is the first time that CmisSync is being run.
         /// </summary>
@@ -146,7 +146,6 @@ namespace CmisSync
                 return firstRun;
             }
         }
-
 
         /// <summary>
         /// The list of synchronized folders.
@@ -164,33 +163,30 @@ namespace CmisSync
             }
         }
 
-
         /// <summary>
         /// Add CmisSync to the list of programs to be started up when the user logs into Windows.
         /// </summary>
         public abstract void CreateStartupItem();
-
 
         /// <summary>
         /// Add CmisSync to the user's Windows Explorer bookmarks.
         /// </summary>
         public abstract void AddToBookmarks();
 
-
         /// <summary>
         /// Creates the CmisSync folder in the user's home folder.
         /// </summary>
         public abstract bool CreateCmisSyncFolder();
-
 
         /// <summary>
         /// Keeps track of whether a download or upload is going on, for display of the task bar animation.
         /// </summary>
         private IActivityListener activityListenerAggregator;
 
-
+        /// <summary>
+        /// 
+        /// </summary>
         private ActiveActivitiesManager activitiesManager;
-
 
         /// <summary>
         /// A folder lock for the base directory.
@@ -201,7 +197,6 @@ namespace CmisSync
         /// Concurrency locks.
         /// </summary>
         private Object repo_lock = new Object();
-
 
         /// <summary>
         /// Constructor.
@@ -216,10 +211,11 @@ namespace CmisSync
             };
         }
 
+        /// <summary></summary>
+        /// <returns></returns>
         public List<FileTransmissionEvent> ActiveTransmissions() {
             return this.activitiesManager.ActiveTransmissions.ToList<FileTransmissionEvent>();
         }
-
 
         /// <summary>
         /// Initialize the controller.
@@ -245,7 +241,6 @@ namespace CmisSync
             folderLock = new FolderLock(FoldersPath);
         }
 
-
         /// <summary>
         /// Once the GUI has loaded, show setup window if it is the first run, or check the repositories.
         /// </summary>
@@ -267,7 +262,6 @@ namespace CmisSync
                 }).Start();
             }
         }
-
 
         /// <summary>
         /// Initialize (in the GUI and syncing mechanism) an existing CmisSync synchronized folder.
@@ -363,7 +357,6 @@ namespace CmisSync
             RemoveDatabase(dbfilename);
         }
 
-
         /// <summary>
         /// Remove the local database associated with a CmisSync synchronized folder.
         /// </summary>
@@ -377,7 +370,6 @@ namespace CmisSync
                 Logger.Info("Removed database: " + databasefile);
             }
         }
-
 
         /// <summary>
         /// Pause or un-pause synchronization for a particular folder.
@@ -410,7 +402,6 @@ namespace CmisSync
                 }
             }
         }
-
 
         /// <summary>
         /// Check the configured CmisSync synchronized folders.
@@ -536,7 +527,6 @@ namespace CmisSync
             ShowSetupWindowEvent(page_type);
         }
 
-
         /// <summary>
         /// Show info about CmisSync
         /// </summary>
@@ -545,7 +535,6 @@ namespace CmisSync
             ShowAboutWindowEvent();
         }
 
-
         /// <summary>
         /// Show an alert to the user.
         /// </summary>
@@ -553,7 +542,6 @@ namespace CmisSync
         {
             AlertNotificationRaised(Properties_Resources.CmisSync + " " + title, message);
         }
-
 
         /// <summary>
         /// Quit CmisSync.
@@ -568,7 +556,6 @@ namespace CmisSync
             Logger.Info("Exiting.");
             Environment.Exit(0);
         }
-
 
         /// <summary>
         /// A download or upload has started, so run task icon animation.

--- a/CmisSync/SetupController.cs
+++ b/CmisSync/SetupController.cs
@@ -29,7 +29,6 @@ using CmisSync.Auth;
 
 namespace CmisSync
 {
-
     /// <summary>
     /// Kind of pages that are used in the folder addition wizards.
     /// </summary>
@@ -67,6 +66,9 @@ namespace CmisSync
         /// Settings page.
         /// </summary>
         Settings,
+        /// <summary>
+        /// 
+        /// </summary>
 		Syncing
     }
 
@@ -83,6 +85,7 @@ namespace CmisSync
         /// Show window event.
         /// </summary>
         public event Action ShowWindowEvent = delegate { };
+
         /// <summary>
         /// Hide window event.
         /// </summary>
@@ -92,6 +95,7 @@ namespace CmisSync
         /// Change page event.
         /// </summary>
         public event ChangePageEventHandler ChangePageEvent = delegate { };
+
         /// <summary>
         /// Change page event.
         /// </summary>
@@ -101,6 +105,7 @@ namespace CmisSync
         /// Update progress bar event.
         /// </summary>
         public event UpdateProgressBarEventHandler UpdateProgressBarEvent = delegate { };
+
         /// <summary>
         /// Update progress bar event.
         /// </summary>
@@ -110,6 +115,7 @@ namespace CmisSync
         /// Update setup continue button.
         /// </summary>
         public event UpdateSetupContinueButtonEventHandler UpdateSetupContinueButtonEvent = delegate { };
+
         /// <summary>
         /// Update setup continue button.
         /// </summary>
@@ -119,6 +125,7 @@ namespace CmisSync
         /// Update add project button event.
         /// </summary>
         public event UpdateAddProjectButtonEventHandler UpdateAddProjectButtonEvent = delegate { };
+
         /// <summary>
         /// Update add project button event.
         /// </summary>
@@ -128,6 +135,7 @@ namespace CmisSync
         /// Change address field event.
         /// </summary>
         public event ChangeAddressFieldEventHandler ChangeAddressFieldEvent = delegate { };
+
         /// <summary>
         /// Change address field event.
         /// </summary>
@@ -137,6 +145,7 @@ namespace CmisSync
         /// Change repository field event.
         /// </summary>
         public event ChangeRepositoryFieldEventHandler ChangeRepositoryFieldEvent = delegate { };
+
         /// <summary>
         /// Change repository field event.
         /// </summary>
@@ -146,6 +155,7 @@ namespace CmisSync
         /// Change path field event.
         /// </summary>
         public event ChangePathFieldEventHandler ChangePathFieldEvent = delegate { };
+
         /// <summary>
         /// Change path field event.
         /// </summary>
@@ -155,6 +165,7 @@ namespace CmisSync
         /// Change user field.
         /// </summary>
         public event ChangeUserFieldEventHandler ChangeUserFieldEvent = delegate { };
+
         /// <summary>
         /// Change user field.
         /// </summary>
@@ -164,12 +175,22 @@ namespace CmisSync
         /// Change password event.
         /// </summary>
         public event ChangePasswordFieldEventHandler ChangePasswordFieldEvent = delegate { };
+
         /// <summary>
         /// Change password event.
         /// </summary>
         public delegate void ChangePasswordFieldEventHandler(string text, string example_text);
 
+        /// <summary>
+        /// 
+        /// </summary>
         public event LocalPathExistsEventHandler LocalPathExists;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
         public delegate bool LocalPathExistsEventHandler(string path);
 
         /// <summary>
@@ -191,22 +212,27 @@ namespace CmisSync
         /// Previous address.
         /// </summary>
         public Uri PreviousAddress { get; private set; }
+
         /// <summary>
         /// Event.
         /// </summary>
         public string PreviousPath { get; private set; }
+
         /// <summary>
         /// Previous repository.
         /// </summary>
         public string PreviousRepository { get; private set; }
+
         /// <summary>
         /// Syncing repository name.
         /// </summary>
         public string SyncingReponame { get; private set; }
+
         /// <summary>
         /// Default repository path..
         /// </summary>
         public string DefaultRepoPath { get; private set; }
+
         /// <summary>
         /// Progress bar percentage.
         /// </summary>
@@ -216,30 +242,37 @@ namespace CmisSync
         /// Saved address.
         /// </summary>
         public Uri saved_address = null;
+
         /// <summary>
         /// Saved remote path.
         /// </summary>
         public string saved_remote_path = "";
+
         /// <summary>
         /// Saved user.
         /// </summary>
         public string saved_user = "";
+
         /// <summary>
         /// Saved password.
         /// </summary>
         public string saved_password = "";
+
         /// <summary>
         /// Saved repository.
         /// </summary>
         public string saved_repository = "";
+
         /// <summary>
         /// Saved sync interval.
         /// </summary>
         public int saved_sync_interval = 15;
+
         /// <summary>
         /// Saved sync at startup
         /// </summary>
         public bool saved_syncatstartup = true;
+
         /// <summary>
         /// Ignored paths.
         /// </summary>
@@ -254,7 +287,6 @@ namespace CmisSync
         /// Whether CmisSync should be started automatically at login.
         /// </summary>
         private bool create_startup_item = true;
-
 
         /// <summary>
         /// Load repositories information from a CMIS endpoint.
@@ -271,7 +303,6 @@ namespace CmisSync
             }
 
         }
-
 
         /// <summary>
         /// Get the list of subfolders contained in a CMIS folder.
@@ -305,7 +336,6 @@ namespace CmisSync
         /// </summary>
         Regex RepositoryRegex = new Regex(@"^([a-zA-Z0-9][^*/><?\|:]*)$");
         Regex RepositoryRegexLinux = new Regex(@"^([a-zA-Z0-9][^*\\><?\|:]*)$");
-
 
         /// <summary>
         /// Constructor.
@@ -365,7 +395,6 @@ namespace CmisSync
             Logger.Debug("SetupController - Exiting constructor.");
         }
 
-
         /// <summary>
         /// User pressed the "Cancel" button, hide window.
         /// </summary>
@@ -380,7 +409,6 @@ namespace CmisSync
             HideWindowEvent();
         }
 
-
         /// <summary>
         /// Check setup page.
         /// </summary>
@@ -389,7 +417,6 @@ namespace CmisSync
             UpdateSetupContinueButtonEvent(true);
         }
 
-
         /// <summary>
         /// First-time wizard has been cancelled, so quit CmisSync.
         /// </summary>
@@ -397,7 +424,6 @@ namespace CmisSync
         {
             Program.Controller.Quit();
         }
-
 
         /// <summary>
         /// Move to second page of the tutorial.
@@ -408,7 +434,6 @@ namespace CmisSync
             ChangePageEvent(PageType.Tutorial);
         }
 
-
         /// <summary>
         /// Tutorial has been skipped, go to last step of wizard.
         /// </summary>
@@ -417,7 +442,6 @@ namespace CmisSync
             TutorialCurrentPage = 4;
             ChangePageEvent(PageType.Tutorial);
         }
-
 
         /// <summary>
         /// Go to next step of the tutorial.
@@ -446,7 +470,6 @@ namespace CmisSync
             }
         }
 
-
         /// <summary>
         /// Checkbox to add CmisSync to the list of programs to be started up when the user logs into Windows.
         /// </summary>
@@ -454,7 +477,6 @@ namespace CmisSync
         {
             this.create_startup_item = create_startup_item;
         }
-
 
         /// <summary>
         /// Check whether the address is syntaxically valid.
@@ -534,7 +556,8 @@ namespace CmisSync
             }
         }
 
-
+        /// <summary></summary>
+        /// <param name="localpath"></param>
         public void CheckRepoPathExists(string localpath)
         {
             if (Directory.Exists(localpath))
@@ -553,7 +576,6 @@ namespace CmisSync
             ChangePageEvent(PageType.Add2);
         }
 
-
         /// <summary>
         /// Switch back from second to first step, presumably to change server or user.
         /// </summary>
@@ -563,7 +585,6 @@ namespace CmisSync
             PreviousPath = saved_user;
             ChangePageEvent(PageType.Add1);
         }
-
 
         /// <summary>
         /// Second step of remote folder addition wizard is complete, switch to customization step.
@@ -595,7 +616,6 @@ namespace CmisSync
         {
             Add2PageCompleted(repository, remote_path, new string[] { }, new string[] { });
         }
-
 
         /// <summary>
         /// Customization step of remote folder addition wizard is complete, start CmisSync.
@@ -641,7 +661,6 @@ namespace CmisSync
             ChangePageEvent(PageType.Finished);
         }
 
-
         /// <summary>
         /// Switch back from customization to step 2 of the remote folder addition wizard.
         /// </summary>
@@ -661,7 +680,6 @@ namespace CmisSync
             FinishPageCompleted();
         }
 
-
         /// <summary>
         /// Folder addition wizard is over, reset it for next use.
         /// </summary>
@@ -673,7 +691,6 @@ namespace CmisSync
             this.FolderAdditionWizardCurrentPage = PageType.None;
             HideWindowEvent();
         }
-
 
         /// <summary>
         /// Repository settings page.

--- a/CmisSync/StatusIconController.cs
+++ b/CmisSync/StatusIconController.cs
@@ -24,7 +24,6 @@ using System.Timers;
 
 namespace CmisSync
 {
-
     /// <summary>
     /// State of the CmisSync status icon.
     /// </summary>
@@ -44,13 +43,11 @@ namespace CmisSync
         Error
     }
 
-
     /// <summary>
     /// MVC controller for the CmisSync status icon.
     /// </summary>
     public class StatusIconController
     {
-
         /// <summary>
         /// Log.
         /// </summary>
@@ -60,6 +57,7 @@ namespace CmisSync
         /// Update icon event.
         /// </summary>
         public event UpdateIconEventHandler UpdateIconEvent = delegate { };
+
         /// <summary>
         /// Update icon event.
         /// </summary>
@@ -69,6 +67,7 @@ namespace CmisSync
         /// Update menu event.
         /// </summary>
         public event UpdateMenuEventHandler UpdateMenuEvent = delegate { };
+
         /// <summary>
         /// Update menu event.
         /// </summary>
@@ -78,6 +77,7 @@ namespace CmisSync
         /// Update status event.
         /// </summary>
         public event UpdateStatusItemEventHandler UpdateStatusItemEvent = delegate { };
+
         /// <summary>
         /// Update status event.
         /// </summary>
@@ -87,12 +87,20 @@ namespace CmisSync
         /// Update suspended sync folder event.
         /// </summary>
         public event UpdateSuspendSyncFolderEventHandler UpdateSuspendSyncFolderEvent = delegate { };
+
         /// <summary>
         /// Update suspended sync folder event.
         /// </summary>
         public delegate void UpdateSuspendSyncFolderEventHandler(string reponame);
 
+        /// <summary>
+        /// 
+        /// </summary>
         public event UpdateTransmissionMenuEventHandler UpdateTransmissionMenuEvent = delegate { };
+
+        /// <summary>
+        /// 
+        /// </summary>
         public delegate void UpdateTransmissionMenuEventHandler();
 
         /// <summary>
@@ -100,24 +108,20 @@ namespace CmisSync
         /// </summary>
         public IconState CurrentState = IconState.Idle;
 
-
         /// <summary>
         /// Short text shown at the top of the menu of the CmisSync tray icon.
         /// </summary>
         public string StateText = Properties_Resources.Welcome;
-
 
         /// <summary>
         /// Maximum number of remote folders in the menu before the overflow menu appears.
         /// </summary>
         public readonly int MenuOverflowThreshold = 9;
 
-
         /// <summary>
         /// Minimum number of remote folders to populate the overflow menu.
         /// </summary>
         public readonly int MinSubmenuOverflowCount = 3;
-
 
         /// <summary>
         /// The list of remote folders to show in the CmisSync tray menu.
@@ -135,7 +139,6 @@ namespace CmisSync
             }
         }
 
-
         /// <summary>
         /// The list of remote folders to show in the CmisSync tray's overflow menu.
         /// </summary>
@@ -151,7 +154,6 @@ namespace CmisSync
                     return new string[0];
             }
         }
-
 
         /// <summary>
         /// Total disk space taken by the sum of the remote folders.
@@ -172,19 +174,16 @@ namespace CmisSync
             }
         }
 
-
         /// <summary>
         /// Timer for the animation that appears when downloading/uploading a file.
         /// </summary>
         private Timer animation;
-
 
         /// <summary>
         /// Current frame of the animation being shown.
         /// First frame is the still icon.
         /// </summary>
         private int animation_frame_number;
-
 
         /// <summary>
         /// Constructor.
@@ -244,7 +243,6 @@ namespace CmisSync
                 this.animation.Start();
             };
 
-
             // Error.
             Program.Controller.OnError += delegate(Tuple<string, Exception> error)
             {
@@ -303,7 +301,6 @@ namespace CmisSync
             };
         }
 
-
         /// <summary>
         /// With the local file explorer, open the folder where the local synchronized folders are.
         /// </summary>
@@ -312,7 +309,6 @@ namespace CmisSync
             Program.Controller.OpenCmisSyncFolder(reponame);
         }
 
-        
         /// <summary>
         /// With the default web browser, open the remote folder of a CmisSync synchronized folder.
         /// </summary>
@@ -339,7 +335,6 @@ namespace CmisSync
             Program.Controller.ShowSetupWindow(PageType.Settings);
         }
 
-
         /// <summary>
         /// Open the remote folder addition wizard.
         /// </summary>
@@ -347,7 +342,6 @@ namespace CmisSync
         {
             Program.Controller.ShowSetupWindow(PageType.Add1);
         }
-
 
         /// <summary>
         /// Open the CmisSync log with a text file viewer.
@@ -357,7 +351,6 @@ namespace CmisSync
             Program.Controller.ShowLog(ConfigManager.CurrentConfig.GetLogFilePath());
         }
 
-
         /// <summary>
         /// Show the About dialog.
         /// </summary>
@@ -365,7 +358,6 @@ namespace CmisSync
         {
             Program.Controller.ShowAboutWindow();
         }
-
 
         /// <summary>
         /// Quit CmisSync.
@@ -375,7 +367,6 @@ namespace CmisSync
             Program.Controller.Quit();
         }
 
-
         /// <summary>
         /// Suspend synchronization for a particular folder.
         /// </summary>
@@ -384,7 +375,6 @@ namespace CmisSync
             Program.Controller.StartOrSuspendRepository(reponame);
             UpdateSuspendSyncFolderEvent(reponame);
         }
-
 
         /// <summary>
         /// Tries to remove a given repo from sync
@@ -423,7 +413,6 @@ namespace CmisSync
         {
             Program.Controller.ManualSync(reponame);
         }
-
 
         /// <summary>
         /// Edit a particular folder.

--- a/CmisSync/TestLibrary/CmisSyncTests.cs
+++ b/CmisSync/TestLibrary/CmisSyncTests.cs
@@ -50,14 +50,13 @@ namespace TestLibrary
     using NUnit.Framework;
     using CmisSync.Auth;
 
+    /// <summary></summary>
     [TestFixture]
     public class CmisSyncTests
     {
-
         private readonly string CMISSYNCDIR = ConfigManager.CurrentConfig.FoldersPath;
         private readonly int HeavyNumber = 10;
         private readonly int HeavyFileSize = 1024;
-
 
         public CmisSyncTests()
         {
@@ -100,6 +99,7 @@ namespace TestLibrary
             }
         }
 
+        /// <summary></summary>
         public static IEnumerable<object[]> TestServers
         {
             get
@@ -117,7 +117,7 @@ namespace TestLibrary
             }
         }
 
-
+        /// <summary></summary>
         public static IEnumerable<object[]> TestServersFuzzy
         {
             get
@@ -135,7 +135,9 @@ namespace TestLibrary
             }
         }
 
-
+        /// <summary></summary>
+        /// <param name="localDirectory"></param>
+        /// <param name="synchronizedFolder"></param>
         private void Clean(string localDirectory, CmisRepo.SynchronizedFolder synchronizedFolder)
         {
 
@@ -148,7 +150,6 @@ namespace TestLibrary
             Directory.Delete(localDirectory);
         }
 
-
         private void DeleteDirectoryIfExists(string path)
         {
             if (Directory.Exists(path))
@@ -156,7 +157,6 @@ namespace TestLibrary
                 Directory.Delete(path, true);
             }
         }
-
 
         private void CleanDirectory(string path)
         {
@@ -180,7 +180,6 @@ namespace TestLibrary
             // Prepare empty directory.
             Directory.CreateDirectory(path);
         }
-
 
         private void CleanAll(string path)
         {
@@ -225,7 +224,6 @@ namespace TestLibrary
             }
         }
 
-
         private ISession CreateSession(RepoInfo repoInfo)
         {
             Dictionary<string, string> cmisParameters = new Dictionary<string, string>();
@@ -238,7 +236,6 @@ namespace TestLibrary
 
             return SessionFactory.NewInstance().CreateSession(cmisParameters);
         }
-
 
         public IDocument CreateDocument(IFolder folder, string name, string content)
         {
@@ -255,7 +252,6 @@ namespace TestLibrary
             return folder.CreateDocument(properties, contentStream, null);
         }
 
-
         public IFolder CreateFolder(IFolder folder, string name)
         {
             Dictionary<string, object> properties = new Dictionary<string, object>();
@@ -264,7 +260,6 @@ namespace TestLibrary
 
             return folder.CreateFolder(properties);
         }
-
 
         public IDocument CopyDocument(IFolder folder, IDocument source, string name)
         {
@@ -275,7 +270,6 @@ namespace TestLibrary
             return folder.CreateDocumentFromSource(source, properties, null);
         }
 
-
         public IDocument RenameDocument(IDocument source, string name)
         {
             Dictionary<string, object> properties = new Dictionary<string, object>();
@@ -284,7 +278,6 @@ namespace TestLibrary
             return (IDocument)source.UpdateProperties(properties);
         }
 
-
         public IFolder RenameFolder(IFolder source, string name)
         {
             Dictionary<string, object> properties = new Dictionary<string, object>();
@@ -292,7 +285,6 @@ namespace TestLibrary
 
             return (IFolder)source.UpdateProperties(properties);
         }
-
 
         public void CreateHeavyFolder(string root)
         {
@@ -315,7 +307,6 @@ namespace TestLibrary
                 }
             }
         }
-
 
         public bool CheckHeavyFolder(string root)
         {
@@ -358,7 +349,6 @@ namespace TestLibrary
             return true;
         }
 
-
         public void CreateHeavyFolderRemote(IFolder root)
         {
             for (int iFolder = 0; iFolder < HeavyNumber; ++iFolder)
@@ -372,16 +362,13 @@ namespace TestLibrary
             }
         }
 
-
         // /////////////////////////// TESTS ///////////////////////////
-
 
         [Test, Category("Fast")]
         public void Placebo()
         {
             Assert.AreEqual(4, 2 + 2);
         }
-
 
         [Test, Category("Fast")]
         public void TestCrypto()
@@ -393,7 +380,6 @@ namespace TestLibrary
                 Assert.AreEqual(Crypto.Deobfuscate(crypted), pass);
             }
         }
-
 
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         public void GetRepositories(string canonical_name, string localPath, string remoteFolderPath,
@@ -412,7 +398,6 @@ namespace TestLibrary
             }
             Assert.NotNull(repos);
         }
-
 
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         public void Sync(string canonical_name, string localPath, string remoteFolderPath,
@@ -452,7 +437,6 @@ namespace TestLibrary
                 }
             }
         }
-
 
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         public void ClientSideSmallFileAddition(string canonical_name, string localPath, string remoteFolderPath,
@@ -519,7 +503,6 @@ namespace TestLibrary
             }
         }
 
-
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         [Ignore]
         public void ClientSideBigFileAddition(string canonical_name, string localPath, string remoteFolderPath,
@@ -583,7 +566,6 @@ namespace TestLibrary
                 }
             }
         }
-
 
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         [Ignore]
@@ -721,7 +703,6 @@ namespace TestLibrary
                 Clean(localDirectory2, synchronizedFolder2);
             }
         }
-
 
         // Goal: Make sure that CmisSync works for uploading modified files.
         [Test, TestCaseSource("TestServers"), Category("Slow")]
@@ -991,7 +972,6 @@ namespace TestLibrary
             }
         }
 
-
         // Goal: Make sure that CmisSync works for remote heavy folder changes.
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         [Ignore]
@@ -1090,8 +1070,8 @@ namespace TestLibrary
                 }
             }
         }
-
-                // Goal: Make sure that CmisSync works for equality.
+        
+        // Goal: Make sure that CmisSync works for equality.
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         public void SyncRenamedFiles(string canonical_name, string localPath, string remoteFolderPath,
             string url, string user, string password, string repositoryId)
@@ -1209,8 +1189,6 @@ namespace TestLibrary
                 Assert.AreEqual(1, localFilesCount2, String.Format("There should exist only one file in the local folder, but there are {0}", localFilesCount2));
             }
         }
-
-
 
         // Goal: Make sure that CmisSync works for equality.
         [Test, TestCaseSource("TestServers"), Category("Slow")]
@@ -1570,7 +1548,6 @@ namespace TestLibrary
             }
         }
 
-
         // Goal: Make sure that CmisSync works for heavy folder.
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         [Ignore]
@@ -1693,7 +1670,6 @@ namespace TestLibrary
             }
         }
 
-
         // Goal: Make sure that CmisSync works for concurrent heavy folder.
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         [Ignore]
@@ -1806,7 +1782,6 @@ namespace TestLibrary
             }
         }
 
-
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         public void ClientSideDirectoryAndSmallFilesAddition(string canonical_name, string localPath, string remoteFolderPath,
             string url, string user, string password, string repositoryId)
@@ -1853,7 +1828,6 @@ namespace TestLibrary
                 }
             }
         }
-
 
         // Goal: Make sure that CmisSync does not crash when syncing while modifying locally.
         [Test, TestCaseSource("TestServers"), Category("Slow")]
@@ -1930,7 +1904,6 @@ namespace TestLibrary
                 }
             }
         }
-
 
         // Goal: Make sure that CmisSync does not crash when syncing while adding/removing files/folders locally.
         [Test, TestCaseSource("TestServers"), Category("Slow")]
@@ -2011,7 +1984,6 @@ namespace TestLibrary
             }
         }
 
-
         // Write a file and immediately check whether it has been created.
         // Should help to find out whether CMIS servers are synchronous or not.
         [Test, TestCaseSource("TestServers"), Category("Slow")]
@@ -2071,7 +2043,6 @@ namespace TestLibrary
             doc.DeleteAllVersions();
         }
 
-
         [Test, TestCaseSource("TestServers"), Category("Slow")]
         [Ignore]
         public void DotCmisToIBMConnections(string canonical_name, string localPath, string remoteFolderPath,
@@ -2109,7 +2080,6 @@ namespace TestLibrary
                 }
             }
         }
-
 
         [Test, TestCaseSource("TestServersFuzzy"), Category("Slow")]
         public void GetRepositoriesFuzzy(string url, string user, string password)
@@ -2192,6 +2162,5 @@ namespace TestLibrary
             Console.WriteLine("Wait was not successful");
             return false;
         }
-
     }
 }

--- a/CmisSync/TestLibrary/DebugLoggingHandlerTest.cs
+++ b/CmisSync/TestLibrary/DebugLoggingHandlerTest.cs
@@ -9,6 +9,7 @@ namespace TestLibrary
     using CmisSync.Lib;
     using CmisSync.Lib.Events;
 
+    /// <summary></summary>
     [TestFixture]
     public class DebugLoggingHandlerTest
     {
@@ -20,7 +21,6 @@ namespace TestLibrary
             log4net.Config.XmlConfigurator.Configure(ConfigManager.CurrentConfig.GetLog4NetConfig());
         }
 
-
         [Test]
         public void ToStringTest() {
             var handler = new DebugLoggingHandler();
@@ -31,7 +31,6 @@ namespace TestLibrary
         public void PriorityTest() {
             var handler = new DebugLoggingHandler();
             Assert.AreEqual(10000, handler.Priority);
-            
         }
         
     }

--- a/CmisSync/TestLibrary/EncodingTest.cs
+++ b/CmisSync/TestLibrary/EncodingTest.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 namespace TestLibrary
 {
+    /// <summary></summary>
     [TestFixture]
     public class EncodingTest
     {

--- a/CmisSync/TestLibrary/EventTypesTest.cs
+++ b/CmisSync/TestLibrary/EventTypesTest.cs
@@ -9,6 +9,7 @@ namespace TestLibrary
     using CmisSync.Lib;
     using CmisSync.Lib.Events;
 
+    /// <summary></summary>
     [TestFixture]
     public class EventTypesTest
     {
@@ -19,7 +20,6 @@ namespace TestLibrary
         {
             log4net.Config.XmlConfigurator.Configure(ConfigManager.CurrentConfig.GetLog4NetConfig());
         }
-
 
         [Test]
         public void FSEventTest() {

--- a/CmisSync/TestLibrary/FSDeletionHandlerTest.cs
+++ b/CmisSync/TestLibrary/FSDeletionHandlerTest.cs
@@ -12,6 +12,7 @@ namespace TestLibrary
     using CmisSync.Lib.Cmis;
     using DotCMIS.Client;
 
+    /// <summary></summary>
     [TestFixture]
     public class FSDeletionHandlerTest
     {
@@ -23,7 +24,6 @@ namespace TestLibrary
             log4net.Config.XmlConfigurator.Configure(ConfigManager.CurrentConfig.GetLog4NetConfig());
         }
 
-
         [Test]
         public void ToStringTest() {
             var handler = new FSDeletionHandler(new Mock<IDatabase>().Object, new Mock<ISession>().Object);
@@ -33,8 +33,7 @@ namespace TestLibrary
         [Test]
         public void PriorityTest() {
             var handler = new FSDeletionHandler(new Mock<IDatabase>().Object, new Mock<ISession>().Object);
-            Assert.AreEqual(100, handler.Priority);
-            
+            Assert.AreEqual(100, handler.Priority); 
         }
         
         [Test]
@@ -50,6 +49,5 @@ namespace TestLibrary
             bool handled = handler.Handle(new Mock<FSEvent>(WatcherChangeTypes.Created, "").Object);
             Assert.False(handled);            
         }
-        
     }
 }

--- a/CmisSync/TestLibrary/SyncEventManagerTest.cs
+++ b/CmisSync/TestLibrary/SyncEventManagerTest.cs
@@ -10,6 +10,7 @@ namespace TestLibrary
     using CmisSync.Lib;
     using CmisSync.Lib.Events;
 
+    /// <summary></summary>
     [TestFixture]
     public class SyncEventManagerTest
     {
@@ -20,7 +21,6 @@ namespace TestLibrary
         {
             log4net.Config.XmlConfigurator.Configure(ConfigManager.CurrentConfig.GetLog4NetConfig());
         }
-
 
         [Test]
         public void AddHandlerTest() {

--- a/CmisSync/TestLibrary/SyncEventQueueTest.cs
+++ b/CmisSync/TestLibrary/SyncEventQueueTest.cs
@@ -11,6 +11,7 @@ namespace TestLibrary
     using CmisSync.Lib;
     using CmisSync.Lib.Events;
 
+    /// <summary></summary>
     [TestFixture]
     public class SyncEventQueueTest
     {

--- a/CmisSync/TestLibrary/WatcherTest.cs
+++ b/CmisSync/TestLibrary/WatcherTest.cs
@@ -10,6 +10,7 @@ namespace TestLibrary
 {
     using NUnit.Framework;
 
+    /// <summary></summary>
     [TestFixture]
     public class WatcherTest
     {
@@ -48,7 +49,6 @@ namespace TestLibrary
             File.Delete(oldnameOut);
             File.Delete(newnameOut);
         }
-
 
         [Test, Category("Fast")]
         public void TestEnableRaisingEvents()
@@ -89,8 +89,10 @@ namespace TestLibrary
             }
         }
 
+        /// <summary></summary>
         public class FileSystemEventCount
         {
+            /// <summary></summary>
             public int Count { get; private set; }
 
             public void OnFileSystemEvent(object e, FileSystemEventArgs args)
@@ -606,6 +608,10 @@ namespace TestLibrary
             Thread.Sleep(milliseconds);
         }
 
+        /// <summary></summary>
+        /// <param name="milliseconds"></param>
+        /// <param name="watcher"></param>
+        /// <param name="expect"></param>
         public static void WaitWatcher(int milliseconds, Watcher watcher, int expect)
         {
 #if __MonoCS__
@@ -623,6 +629,10 @@ namespace TestLibrary
             Console.WriteLine("Timeout");
         }
 
+        /// <summary></summary>
+        /// <param name="milliseconds"></param>
+        /// <param name="watcher"></param>
+        /// <param name="checkStop"></param>
         public static void WaitWatcher(int milliseconds, Watcher watcher, Func<Watcher,bool> checkStop)
         {
 #if __MonoCS__

--- a/CmisSync/Windows/About.cs
+++ b/CmisSync/Windows/About.cs
@@ -52,7 +52,7 @@ namespace CmisSync {
             Title      = Properties_Resources.ResourceManager.GetString("About", CultureInfo.CurrentCulture);
             ResizeMode = ResizeMode.NoResize;
             Height     = 288;
-            Width      = 640;
+            Width      = 1640;
             Icon = UIHelpers.GetImageSource("cmissync-app", "ico");
 
             WindowStartupLocation = WindowStartupLocation.CenterScreen;

--- a/CmisSync/Windows/PollIntervalSlider.cs
+++ b/CmisSync/Windows/PollIntervalSlider.cs
@@ -20,12 +20,10 @@ namespace CmisSync
     {
         protected static readonly ILog Logger = LogManager.GetLogger(typeof(PollIntervalSlider));
 
-
         /// <summary>
         /// Tooltip that shows poll interval  when mouse goes over the slider.
         /// </summary>
         private ToolTip _autoToolTip;
-
 
         /// <summary>
         /// Poll interval shown/tuned by the slider.
@@ -38,7 +36,6 @@ namespace CmisSync
                 this.Value = LogScaleConverter.Convert(value);
             }
         }
-
 
         /// <summary>
         /// Constructor.
@@ -68,13 +65,11 @@ namespace CmisSync
             this.Ticks = tickMarks;
         }
 
-
         protected override void OnThumbDragStarted(DragStartedEventArgs e)
         {
             base.OnThumbDragStarted(e);
             this.FormatAutoToolTipContent();
         }
-
 
         protected override void OnThumbDragDelta(DragDeltaEventArgs e)
         {
@@ -82,18 +77,21 @@ namespace CmisSync
             this.FormatAutoToolTipContent();
         }
 
-
+        /// <summary></summary>
+        /// <returns></returns>
         public string FormattedMaximum()
         {
             return FormatToolTip((int)this.Maximum);
         }
 
-
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
         public string FormattedMinimum()
         {
             return FormatToolTip((int)this.Minimum);
         }
-
 
         private string FormatToolTip(int value)
         {
@@ -125,12 +123,10 @@ namespace CmisSync
             }
         }
 
-
         private void FormatAutoToolTipContent()
         {
             this.AutoToolTip.Content = FormatToolTip((int)this.Value);
         }
-
 
         private ToolTip AutoToolTip
         {
@@ -147,18 +143,23 @@ namespace CmisSync
         }
     }
 
-
+    /// <summary></summary>
     public class LogScaleConverter
     {
+        /// <summary></summary>
         protected static readonly ILog Logger = LogManager.GetLogger(typeof(LogScaleConverter));
 
-
+        /// <summary></summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static int Convert(int value)
         {
             return (int)Math.Log((double)value);
         }
 
-
+        /// <summary></summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static int ConvertBack(int value)
         {
             Logger.Debug("ConvertBack " + value + " type:" + value.GetType());

--- a/CmisSync/Windows/WindowsPathRepresentationConverter.cs
+++ b/CmisSync/Windows/WindowsPathRepresentationConverter.cs
@@ -4,9 +4,12 @@ using CmisSync.Lib;
 
 namespace CmisSync
 {
+    /// <summary></summary>
     public class WindowsPathRepresentationConverter : IPathRepresentationConverter
     {
-    
+        /// <summary></summary>
+        /// <param name="localPath"></param>
+        /// <returns></returns>
         public string LocalToRemote(string localPath)
         {
             if (string.IsNullOrEmpty(localPath))
@@ -17,6 +20,9 @@ namespace CmisSync
             return localPath.Replace('\\', '/');
         }
 
+        /// <summary></summary>
+        /// <param name="remotePath"></param>
+        /// <returns></returns>
         public string RemoteToLocal(string remotePath)
         {
             if (String.IsNullOrEmpty(remotePath))


### PR DESCRIPTION
Code cleanup on XML Comments and Whitespace only.  No active code has
been modified.

NOTE: Windows\About.cs accidentally modified, needs to be reverted!
