### PR TITLE
[Linux] Fix icons for all themes and make whole installation use /usr/local/

### DIFF
--- a/CmisSync/Linux/Pixmaps/icons/Makefile.am
+++ b/CmisSync/Linux/Pixmaps/icons/Makefile.am
@@ -6,6 +6,12 @@ system_themedir = $(datadir)/icons/$(theme)
 app_themedir = $(pkgdatadir)/icons/$(theme)
 
 system_theme_icons = \
+	status,process-syncing-i-24.png \
+	status,process-syncing-ii-24.png \
+	status,process-syncing-iii-24.png \
+	status,process-syncing-iiii-24.png \
+	status,process-syncing-iiiii-24.png \
+	status,process-syncing-error-24.png	\
 	apps,app-cmissync-16.png \
 	apps,app-cmissync-22.png	\
 	apps,app-cmissync-24.png \

--- a/CmisSync/Linux/Pixmaps/icons/ubuntu-mono-dark/Makefile.am
+++ b/CmisSync/Linux/Pixmaps/icons/ubuntu-mono-dark/Makefile.am
@@ -1,5 +1,5 @@
 dark_theme = ubuntu-mono-dark
-dark_themedir = /usr/share/icons/$(dark_theme)
+dark_themedir = /usr/local/share/icons/$(dark_theme)
 
 dark_theme_icons = \
 	status,process-syncing-i-24.png \

--- a/CmisSync/Linux/Pixmaps/icons/ubuntu-mono-light/Makefile.am
+++ b/CmisSync/Linux/Pixmaps/icons/ubuntu-mono-light/Makefile.am
@@ -1,5 +1,5 @@
 light_theme = ubuntu-mono-light
-light_themedir = /usr/share/icons/$(light_theme)
+light_themedir = /usr/local/share/icons/$(light_theme)
 
 light_theme_icons = \
 	status,process-syncing-i-24.png \

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-m4_define([cmissync_version], [2.2.3])
+m4_define([cmissync_version], [2.4.0])
 
 AC_PREREQ([2.54])
 AC_INIT([CmisSync], cmissync_version)


### PR DESCRIPTION
I've separated the work into 3 commits, so easier to modify this PR if there are any unsuitable bits.

## Commit 1 - Main fix to allow icons to work across all themes

http://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html:
> ### Directory Layout
> ...
> 
> In order to have a place for third party applications to install their icons there should always exist a theme called "hicolor" [1]. ... Implementations are required to look in the "hicolor" theme if an icon was not found in the current theme.

* Since the application's icons are already being installed under `/usr/local/share/icons/hicolor`, just copied the relevant lines to that part of the Makefile
* Only query remaining now: is there any reason to install these same image files to `/usr/local/share/cmissync/icons/hicolor/24x24/status`?  If not, these lines can be removed.

## Commit 2 - Consistency of paths used for the installation
Historically there's been a big debate about `/usr` vs. `/usr/local`.  Perhaps the following quote is a useful guideline.

http://www.linuxfromscratch.org/blfs/view/7.6/introduction/position.html:
> ### The /usr Versus /usr/local Debate
> ...
> 
> With Linux distributions like Red Hat, Debian, etc., a possible rule is that `/usr` is managed by the distribution's package system and `/usr/local` is not. This way the package manager's database knows about every file within `/usr`. 

If this rule is adopted:
* CmisSync installations via. source => `/usr/local`
* CmisSync installations via. package => `/usr`

Probably better practice to avoid installing some of the files in `/usr/local` and some under `/usr`.

## Commit 3 - Version number
This is straightforward and can either be included or excluded as required.