### PR TITLE
Create DEBIAN scripts for post installation/removal tasks

### DIFF
--- a/build/DEBIAN/postinst
+++ b/build/DEBIAN/postinst
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+update_icon_cache () {
+    if [ -d ${DIR} ]; then
+        gtk-update-icon-cache -f -t ${DIR}
+    fi
+}
+
+DIR=/usr/local/share/cmissync/icons/hicolor
+update_icon_cache
+
+DIR=/usr/local/share/icons/hicolor
+update_icon_cache
+
+DIR=/usr/local/share/icons/ubuntu-mono-dark
+update_icon_cache
+
+DIR=/usr/local/share/icons/ubuntu-mono-light
+update_icon_cache
+
+exit 0
+

--- a/build/DEBIAN/postrm
+++ b/build/DEBIAN/postrm
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+update_icon_cache () {
+    if [ -d ${DIR} ]; then
+        gtk-update-icon-cache -f -t ${DIR}
+    fi
+}
+
+DIR=/usr/local/share/cmissync/icons/hicolor
+update_icon_cache
+
+DIR=/usr/local/share/icons/hicolor
+update_icon_cache
+
+DIR=/usr/local/share/icons/ubuntu-mono-dark
+update_icon_cache
+
+DIR=/usr/local/share/icons/ubuntu-mono-light
+update_icon_cache
+
+exit 0
+


### PR DESCRIPTION
### Commit summary
* gtk-update-icon-cache needs to be run for each icon directory
* Needs to be done after package installation and removal
* Considers existing icon cache that may already be present

### Purpose
* Without generating the icon caches, the application and status icons will not be available
* From what I understand, these scripts will not be required if installing to `/usr` since that will be handled by the package manager - so these are a temporary fix while `/usr/local` is being used for this .deb installation

### Why can't the icon cache files just be included in the .deb file?
* A user may already have some icons in one of these directories
* If that cache is overwritten without being regenerated, the previous icons will no longer be available and the user has every right to be peeved
* Basically, these scripts need to run in any case, whether other icons existed before or not

### Why `postrm` script as well?
* This is identical to the `postinst` script
* This is in case the user still has icons in those directories, their icon caches will be regenerated after CmisSync is removed from their computer

### Changes to the wiki [Linux DEB]
Some notes about changes made to https://github.com/aegif/CmisSync/wiki/Packaging#linux-deb:
* `rsync -R` creates the directory paths without having to use `mkdir -p` over and over
* One concatenated block of commands to speed up the process with a single copy-paste
* Open `DEBIAN/control` ready for editing - change `vim` to editor of choice
* `fakeroot` - see https://gist.github.com/bdsatish/00ee8a21e298f2b20d9d:

> #### 6. Build the package
> 
> This is the main step you've been waiting for. `dpkg -b` is a shorcut for `dpkg-deb --build`.
> ```
> cd $PKGDIR/..
> sudo apt-get install fakeroot
> fakeroot dpkg -b $PKGDIR          # This takes a while
> 
> ls package_1.2.3-xyz1_amd64.deb   # check that the .deb is created
> ```
> The `fakeroot` command enables to `chown root:root` ownership of files without actually being root or needing sudo. `dpkg -b` only needs the `control` file created in Step 3. Everything else is optional.