### PR TITLE
fix #559 and other minor improvements

### DIFF
--- a/CmisSync.Lib/Cmis/PermissionDeniedException.cs
+++ b/CmisSync.Lib/Cmis/PermissionDeniedException.cs
@@ -34,4 +34,36 @@ namespace CmisSync.Lib.Cmis
         /// </summary>
         protected PermissionDeniedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
+    
+    /// <summary>
+    /// Exception launched when the root sync folder is not found.
+    /// </summary>
+    [Serializable]
+    public class MissingSyncFolderException : BaseException
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public MissingSyncFolderException() { }
+        
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public MissingSyncFolderException(string message) : base(message) { }
+        
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public MissingSyncFolderException(string message, Exception inner) : base(message, inner) { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public MissingSyncFolderException(Exception inner) : base(inner) { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        protected MissingSyncFolderException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
 }

--- a/CmisSync.Lib/CmisSync.Lib.csproj
+++ b/CmisSync.Lib/CmisSync.Lib.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Events\SyncEventManager.cs" />
     <Compile Include="Events\SyncEventQueue.cs" />
     <Compile Include="Sync\ChangeLogThenCrawlStrategy.cs" />
+    <Compile Include="Sync\exceptions.cs" />
     <Compile Include="UserNotificationListener.cs" />
     <Compile Include="Cmis\BaseException.cs" />
     <Compile Include="Database\Database.cs" />

--- a/CmisSync.Lib/Sync/CrawlStrategy.cs
+++ b/CmisSync.Lib/Sync/CrawlStrategy.cs
@@ -220,7 +220,7 @@ namespace CmisSync.Lib.Sync
                     }
                     else
                     {
-                        Logger.Debug("Unknown object type: " + cmisObject.ObjectType.DisplayName
+                        Logger.Warn("Unknown object type: " + cmisObject.ObjectType.DisplayName
                             + " for object " + remoteFolder + "/" + cmisObject.Name);
                     }
                 }

--- a/CmisSync.Lib/Sync/SynchronizedFolder.cs
+++ b/CmisSync.Lib/Sync/SynchronizedFolder.cs
@@ -439,7 +439,7 @@ namespace CmisSync.Lib.Sync
                         else
                         {
                             //  Have to crawl remote.
-                            Logger.Debug("Invoke a full crawl sync");
+                            Logger.Warn("Invoke a full crawl sync (the remote does not support ChangeLog)");
                             repo.Watcher.Clear();
                             CrawlSyncAndUpdateChangeLogToken(remoteFolder, localFolder);
                         }
@@ -624,6 +624,7 @@ namespace CmisSync.Lib.Sync
 
                 Logger.Error(logMessage, exception);
 
+                //FIXME: should we remove the file after an error?
                 if (!recoverable)
                 {
                     throw exception;

--- a/CmisSync.Lib/Sync/SynchronizedFolder.cs
+++ b/CmisSync.Lib/Sync/SynchronizedFolder.cs
@@ -193,6 +193,10 @@ namespace CmisSync.Lib.Sync
                         {
                             repo.OnSyncError(new PermissionDeniedException("Authentication failed.", e));
                         }
+                        catch (CmisMissingSyncFolderException e) 
+                        {
+                            repo.OnSyncError(new MissingSyncFolderException("Missing sync folder.", e));
+                        }
                         catch (Exception e)
                         {
                             repo.OnSyncError(new BaseException(e));
@@ -428,6 +432,12 @@ namespace CmisSync.Lib.Sync
                     }
                     else
                     {
+                        //fix #559 Content remotely deleted if synced folder removed while CmisSync is running
+                        if (!Directory.Exists(localFolder)) { 
+                            //the user has deleted/moved/rebnamed the local root folder.
+                            throw new CmisMissingSyncFolderException("Missing " + localFolder + ".");
+                        }
+
                         // Apply local changes noticed by the filesystem watcher.
                         WatcherSync(remoteFolderPath, localFolder);
 

--- a/CmisSync.Lib/Sync/SynchronizedFolder.cs
+++ b/CmisSync.Lib/Sync/SynchronizedFolder.cs
@@ -384,6 +384,8 @@ namespace CmisSync.Lib.Sync
                     autoResetEvent.Reset();
                     repo.OnSyncStart(syncFull);
 
+                    SleepWhileSuspended();
+
                     // If not connected, connect.
                     if (session == null)
                     {
@@ -395,8 +397,6 @@ namespace CmisSync.Lib.Sync
                         //  Force to reset the cache for each Sync
                         session.Clear();
                     }
-
-                    SleepWhileSuspended();
 
 
                     // Add ACL in the context, or ACL is null

--- a/CmisSync.Lib/Sync/exceptions.cs
+++ b/CmisSync.Lib/Sync/exceptions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace DotCMIS.Exceptions
+{
+    [Serializable]
+    public class CmisMissingSyncFolderException : CmisBaseException
+    {
+        public CmisMissingSyncFolderException() : base() { }
+        public CmisMissingSyncFolderException(string message) : base(message) { }
+        public CmisMissingSyncFolderException(string message, Exception inner) : base(message, inner) { }
+        protected CmisMissingSyncFolderException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context) { }
+        public CmisMissingSyncFolderException(string message, long? code)
+            : base(message) { }
+        public CmisMissingSyncFolderException(string message, string errorContent)
+            : base(message) { }
+        public CmisMissingSyncFolderException(string message, string errorContent, Exception inner)
+            : base(message, errorContent, inner) { }
+    }
+
+}

--- a/CmisSync.Lib/Utils.cs
+++ b/CmisSync.Lib/Utils.cs
@@ -200,7 +200,7 @@ namespace CmisSync.Lib
 
             if (fullPath.Length > (int)maxPathField.GetValue(null))
             {
-                Logger.DebugFormat("Skipping {0}: path too long", fullPath);
+                Logger.WarnFormat("Skipping {0}: path too long", fullPath);
                 return false;
 
             }

--- a/CmisSync/ControllerBase.cs
+++ b/CmisSync/ControllerBase.cs
@@ -352,7 +352,30 @@ namespace CmisSync
         /// Pause or un-pause synchronization for a particular folder.
         /// </summary>
         /// <param name="repoName">the folder to pause/unpause</param>
-        public void StartOrSuspendRepository(string repoName)
+        public void SuspendOrResumeRepositorySynchronization(string repoName)
+        {
+            lock (this.repo_lock)
+            {
+                //FIXME: why are we sospendig all repositories instead of the one passed?
+                foreach (RepoBase aRepo in this.repositories)
+                {
+                    if (aRepo.Status != SyncStatus.Suspend)
+                    {
+                        SuspendRepositorySynchronization(repoName);
+                    }
+                    else
+                    {
+                        ResumeRepositorySynchronization(repoName);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Pause synchronization for a particular folder.
+        /// </summary>
+        /// <param name="repoName">the folder to pause</param>
+        public void SuspendRepositorySynchronization(string repoName)
         {
             lock (this.repo_lock)
             {
@@ -364,14 +387,22 @@ namespace CmisSync
                         aRepo.Suspend();
                         Logger.Debug("Requested to suspend sync of repo " + aRepo.Name);
                     }
-                    else
-                    {
-                        if (aRepo.Status != SyncStatus.Suspend)
-                        {
-                            aRepo.Suspend();
-                            Logger.Debug("Requested to syspend sync of repo " + aRepo.Name);
                         }
-                        else
+            }
+        }
+
+        /// <summary>
+        /// Un-pause synchronization for a particular folder.
+        /// </summary>
+        /// <param name="repoName">the folder to unpause</param>
+        public void ResumeRepositorySynchronization(string repoName)
+        {
+            lock (this.repo_lock)
+            {
+                //FIXME: why are we sospendig all repositories instead of the one passed?
+                foreach (RepoBase aRepo in this.repositories)
+                {
+                    if (aRepo.Status == SyncStatus.Suspend)
                         {
                             aRepo.Resume();
                             Logger.Debug("Requested to resume sync of repo " + aRepo.Name);
@@ -379,7 +410,6 @@ namespace CmisSync
                     }
                 }
             }
-        }
 
         /// <summary>
         /// Check the configured CmisSync synchronized folders.

--- a/CmisSync/ControllerBase.cs
+++ b/CmisSync/ControllerBase.cs
@@ -356,6 +356,7 @@ namespace CmisSync
         {
             lock (this.repo_lock)
             {
+                //FIXME: why are we sospendig all repositories instead of the one passed?
                 foreach (RepoBase aRepo in this.repositories)
                 {
                     if (aRepo.Status != SyncStatus.Suspend)
@@ -404,7 +405,6 @@ namespace CmisSync
                     }
                 }
 
-                Config.SyncConfig.Folder missingFolder;
                 while (missingFolders.Count != 0)
                 {
                     handleMissingFolder(missingFolders.Dequeue());
@@ -613,6 +613,7 @@ namespace CmisSync
         /// </summary>
         public void ActivityError(Tuple<string, Exception> error)
         {
+            //FIXME: why a Tuple? We should get delegate(ErrorEvent event) or delegate(string repoName, Exception error)
             OnError(error);
         }
     }

--- a/CmisSync/StatusIconController.cs
+++ b/CmisSync/StatusIconController.cs
@@ -259,10 +259,13 @@ namespace CmisSync
             // Error.
             Program.Controller.OnError += delegate(Tuple<string, Exception> error)
             {
-                Logger.Error(String.Format("Error syncing '{0}': {1}", error.Item1, error.Item2.Message), error.Item2);
                 //FIXME: why a Tuple? We should get delegate(ErrorEvent event) or delegate(string repoName, Exception error)
+                String reponame = error.Item1;
+                Exception exception = error.Item2;
 
-                string message = String.Format(Properties_Resources.SyncError, error.Item1, error.Item2.Message);
+                Logger.Error(String.Format("Error syncing '{0}': {1}", reponame, exception.Message), exception);
+
+                string message = String.Format(Properties_Resources.SyncError, reponame, exception.Message);
 
                 IconState PreviousState = CurrentState;
                 CurrentState = IconState.Error;
@@ -277,11 +280,11 @@ namespace CmisSync
                 UpdateMenuEvent(CurrentState);
 #endif
 
-                if (error.Item2 is PermissionDeniedException)
+                if (exception is PermissionDeniedException)
                 {
                     //FIXME: why it get suspended? Instead i should ask the user if the password has changed and he want to enter a new one
                     //Suspend sync...
-                    SuspendSyncClicked(error.Item1);
+                    SuspendSyncClicked(reponame);
                 }
 
                 if (PreviousState != IconState.Error)
@@ -367,7 +370,7 @@ namespace CmisSync
         /// </summary>
         public void SuspendSyncClicked(string reponame)
         {
-            Program.Controller.StartOrSuspendRepository(reponame);
+            Program.Controller.SuspendOrResumeRepositorySynchronization(reponame);
             //TODO: the StatusIcon should listen the controlleo or the repository for Suspended changes instead of call UpdateSuspendSyncFolderEvent
             UpdateSuspendSyncFolderEvent(reponame);
         }

--- a/CmisSync/StatusIconController.cs
+++ b/CmisSync/StatusIconController.cs
@@ -260,6 +260,7 @@ namespace CmisSync
             Program.Controller.OnError += delegate(Tuple<string, Exception> error)
             {
                 Logger.Error(String.Format("Error syncing '{0}': {1}", error.Item1, error.Item2.Message), error.Item2);
+                //FIXME: why a Tuple? We should get delegate(ErrorEvent event) or delegate(string repoName, Exception error)
 
                 string message = String.Format(Properties_Resources.SyncError, error.Item1, error.Item2.Message);
 
@@ -278,6 +279,7 @@ namespace CmisSync
 
                 if (error.Item2 is PermissionDeniedException)
                 {
+                    //FIXME: why it get suspended? Instead i should ask the user if the password has changed and he want to enter a new one
                     //Suspend sync...
                     SuspendSyncClicked(error.Item1);
                 }
@@ -366,6 +368,7 @@ namespace CmisSync
         public void SuspendSyncClicked(string reponame)
         {
             Program.Controller.StartOrSuspendRepository(reponame);
+            //TODO: the StatusIcon should listen the controlleo or the repository for Suspended changes instead of call UpdateSuspendSyncFolderEvent
             UpdateSuspendSyncFolderEvent(reponame);
         }
 


### PR DESCRIPTION
Hi,

I've managed to fix the bug #559 (if the user delete the sync folder while cmisSync running all files on remote are deleted).

Now it ask the user what to do, as when the program start without finding the folder.
There is one small problem:
if the user suspend a repository synchronization and then delete (move or rename) the folder, the next time the program will start it will ask what to do and will resume the sync.

I've also put some "FIXME" and "TODO" comments; i'd like you to check them to see if I get it wrong