### PR TITLE
Update README.md

### DIFF
--- a/CmisSync/Linux/README.md
+++ b/CmisSync/Linux/README.md
@@ -55,7 +55,7 @@ At the root of the CmisSync root folder, run the following commands:
 $ git submodule init
 $ git submodule update
 $ make -f Makefile.am
-$ ./configure --with-dotcmis=Extras/DotCMIS.dll
+$  ./configure --with-dotcmis=Extras/DotCMIS.dll --with-newtonsoft-json=Extras/Newtonsoft.Json.dll
 $ make
 ```
 


### PR DESCRIPTION
As described in #741 the configure command does only work with the "--with-newtonsoft-json=Extras/Newtonsoft.Json.dll"-appendix on Arch Linux. As this change shouldn't do any harm to the installation process on other platforms, it should be the standard recommendation in my opinion.